### PR TITLE
MXWAR-34:chore:add MPL 2.0 license header to all source files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'

--- a/index.html
+++ b/index.html
@@ -1,3 +1,10 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
 <!doctype html>
 <html lang="en">
   <head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { BrowserRouter } from "react-router-dom";
 import { Provider } from "react-redux";
 import { store } from "@/app/store";

--- a/src/app/hook.ts
+++ b/src/app/hook.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useDispatch, useSelector } from 'react-redux'
 import type { RootState, AppDispatch } from './store'
 

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from '@/pages/login/loginSlice'
 

--- a/src/components/custom/breadcrumbs/AppBreadCrumbs.tsx
+++ b/src/components/custom/breadcrumbs/AppBreadCrumbs.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import {
     Breadcrumb,
     BreadcrumbItem,

--- a/src/components/custom/navbar/Dropdown.tsx
+++ b/src/components/custom/navbar/Dropdown.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,

--- a/src/components/custom/navbar/MfNavbar.tsx
+++ b/src/components/custom/navbar/MfNavbar.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { SidebarTrigger } from "@/components/ui/sidebar";
 
 import DropDown from "@/components/custom/navbar/Dropdown";

--- a/src/components/custom/search/AppSearch.tsx
+++ b/src/components/custom/search/AppSearch.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 
 interface AppSearchProps {

--- a/src/components/custom/select/AppSelect.tsx
+++ b/src/components/custom/select/AppSelect.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Label } from "@/components/ui/label";
 import {
     Select,

--- a/src/components/custom/sidebar/AppSidebar.tsx
+++ b/src/components/custom/sidebar/AppSidebar.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import MifosLogo from "@/assets/images/MifosX_logo.png";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";

--- a/src/components/custom/stepper/AppStepper.tsx
+++ b/src/components/custom/stepper/AppStepper.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Button } from "@/components/ui/button";
 import { useState, type ReactNode } from "react";
 

--- a/src/components/custom/tabs/AppTabs.tsx
+++ b/src/components/custom/tabs/AppTabs.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom"
 

--- a/src/components/styles/accordion.ts
+++ b/src/components/styles/accordion.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const accordionRootClass="focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180"

--- a/src/components/styles/alert-dialog.ts
+++ b/src/components/styles/alert-dialog.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const alertDialogRootClass="bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg"

--- a/src/components/styles/button.ts
+++ b/src/components/styles/button.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const buttonRootClass="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"

--- a/src/components/styles/checkbox.ts
+++ b/src/components/styles/checkbox.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const checkboxRootClass="peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50"

--- a/src/components/styles/dropdown-menu.ts
+++ b/src/components/styles/dropdown-menu.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const dropdownMenuContentRoot="bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md"
 
 export const dropdownMenuItemRoot="focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"

--- a/src/components/styles/input.ts
+++ b/src/components/styles/input.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const inputRootState="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"

--- a/src/components/styles/label.ts
+++ b/src/components/styles/label.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const labelRootState="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50"

--- a/src/components/styles/select.ts
+++ b/src/components/styles/select.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const selectTriggerRoot="border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 
 export const selectContentRoot="bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md"

--- a/src/components/styles/toggle.ts
+++ b/src/components/styles/toggle.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const toggleRootClass="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap"

--- a/src/components/styles/tooltip.ts
+++ b/src/components/styles/tooltip.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 export const tooltipContentRoot="bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance"

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
 import { ChevronDownIcon } from "lucide-react"

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { ChevronRight, MoreHorizontal } from "lucide-react"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import {
   ChevronDownIcon,

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { CheckIcon } from "lucide-react"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { CircleIcon } from "lucide-react"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 "use client"
 
 import * as React from "react"

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva } from "class-variance-authority"

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { cn } from "@/lib/utils"
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as SwitchPrimitive from "@radix-ui/react-switch"
 

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
 import { type VariantProps } from "class-variance-authority"

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 "use client"
 
 import * as React from "react"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 "use client"
 
 import * as React from "react"

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 @import "tailwindcss";
 @import "tw-animate-css";
 

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import MfNavbar from "@/components/custom/navbar/MfNavbar"
 import { AppSidebar } from "@/components/custom/sidebar/AppSidebar"
 import { SidebarProvider } from "@/components/ui/sidebar"

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import axios from "axios";
 
 const fineract = axios.create({

--- a/src/lib/fineract-openapi.ts
+++ b/src/lib/fineract-openapi.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 //This file has the configuration for base url for fineract using openapi generator
 
 import { Configuration } from "@/fineract-api";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'

--- a/src/pages/accounting/Accounting.tsx
+++ b/src/pages/accounting/Accounting.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {

--- a/src/pages/accounting/accounting-rules/AccountingRules.tsx
+++ b/src/pages/accounting/accounting-rules/AccountingRules.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {

--- a/src/pages/accounting/accounting-rules/ViewAccountingRules.tsx
+++ b/src/pages/accounting/accounting-rules/ViewAccountingRules.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";

--- a/src/pages/accounting/chart-of-accounts/ChartOfAccounts.tsx
+++ b/src/pages/accounting/chart-of-accounts/ChartOfAccounts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/accounting/chart-of-accounts/CreateGlAccounts.tsx
+++ b/src/pages/accounting/chart-of-accounts/CreateGlAccounts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/accounting/chart-of-accounts/EditGlAccounts.tsx
+++ b/src/pages/accounting/chart-of-accounts/EditGlAccounts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/accounting/chart-of-accounts/ViewGlAccounts.tsx
+++ b/src/pages/accounting/chart-of-accounts/ViewGlAccounts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/accounting/closing-entries/Closure.tsx
+++ b/src/pages/accounting/closing-entries/Closure.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";

--- a/src/pages/accounting/closing-entries/CreateClosure.tsx
+++ b/src/pages/accounting/closing-entries/CreateClosure.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/accounting/closing-entries/EditClosure.tsx
+++ b/src/pages/accounting/closing-entries/EditClosure.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/accounting/closing-entries/ViewClosure.tsx
+++ b/src/pages/accounting/closing-entries/ViewClosure.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";

--- a/src/pages/accounting/create-journal-entry/CreateJournalEntry.tsx
+++ b/src/pages/accounting/create-journal-entry/CreateJournalEntry.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/accounting/create-journal-entry/SearchJournalEntry.tsx
+++ b/src/pages/accounting/create-journal-entry/SearchJournalEntry.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";

--- a/src/pages/accounting/financial-activity-mappings/CreateFinancialActivityMappings.tsx
+++ b/src/pages/accounting/financial-activity-mappings/CreateFinancialActivityMappings.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import AppSelect from "@/components/custom/select/AppSelect";
 import { Button } from "@/components/ui/button";

--- a/src/pages/accounting/financial-activity-mappings/FinancialActivityMappings.tsx
+++ b/src/pages/accounting/financial-activity-mappings/FinancialActivityMappings.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";

--- a/src/pages/accounting/financial-activity-mappings/ViewFinancialActivityMappings.tsx
+++ b/src/pages/accounting/financial-activity-mappings/ViewFinancialActivityMappings.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";

--- a/src/pages/accounting/frequent-postings/FrequentPostings.tsx
+++ b/src/pages/accounting/frequent-postings/FrequentPostings.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/accounting/periodic-accruals/PeriodicAccruals.tsx
+++ b/src/pages/accounting/periodic-accruals/PeriodicAccruals.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/accounting/provisioning-entries/ProvisioningEntries.tsx
+++ b/src/pages/accounting/provisioning-entries/ProvisioningEntries.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus, FileText, RotateCcw, NotebookText } from "lucide-react";

--- a/src/pages/centers/Centers.tsx
+++ b/src/pages/centers/Centers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/centers/CloseCenters.tsx
+++ b/src/pages/centers/CloseCenters.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/centers/CreateCenters.tsx
+++ b/src/pages/centers/CreateCenters.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/centers/EditCenters.tsx
+++ b/src/pages/centers/EditCenters.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
   import { useEffect, useState } from "react";
   import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/centers/centers-view/CentersView.tsx
+++ b/src/pages/centers/centers-view/CentersView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/pages/centers/centers-view/general-tab/CentersGeneralTab.tsx
+++ b/src/pages/centers/centers-view/general-tab/CentersGeneralTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/centers/centers-view/notes-tab/CentersNotesTab.tsx
+++ b/src/pages/centers/centers-view/notes-tab/CentersNotesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/clients/Clients.tsx
+++ b/src/pages/clients/Clients.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/clients/clients-view/ClientsView.tsx
+++ b/src/pages/clients/clients-view/ClientsView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Outlet, useParams } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/pages/clients/clients-view/Identities-tab/ClientsidentitiesTab.tsx
+++ b/src/pages/clients/clients-view/Identities-tab/ClientsidentitiesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";

--- a/src/pages/clients/clients-view/address-tab/ClientsAddressTab.tsx
+++ b/src/pages/clients/clients-view/address-tab/ClientsAddressTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 // import { useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";

--- a/src/pages/clients/clients-view/charges/view-charge/ViewCharge.tsx
+++ b/src/pages/clients/clients-view/charges/view-charge/ViewCharge.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/clients/clients-view/documents-tab/ClientsDocumentsTab.tsx
+++ b/src/pages/clients/clients-view/documents-tab/ClientsDocumentsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";

--- a/src/pages/clients/clients-view/family-members-tab/ClientsFamilyMembersAddTab.tsx
+++ b/src/pages/clients/clients-view/family-members-tab/ClientsFamilyMembersAddTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/clients/clients-view/family-members-tab/ClientsFamilyMembersTab.tsx
+++ b/src/pages/clients/clients-view/family-members-tab/ClientsFamilyMembersTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/clients/clients-view/general-tab/ClientsGeneralTab.tsx
+++ b/src/pages/clients/clients-view/general-tab/ClientsGeneralTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/clients/clients-view/notes-tab/ClientsNotesTab.tsx
+++ b/src/pages/clients/clients-view/notes-tab/ClientsNotesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/collections/IndividualCollectionSheet.tsx
+++ b/src/pages/collections/IndividualCollectionSheet.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/groups/CreateGroups.tsx
+++ b/src/pages/groups/CreateGroups.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/groups/Groups.tsx
+++ b/src/pages/groups/Groups.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/GroupsView.tsx
+++ b/src/pages/groups/groups-view/GroupsView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import Dropdown from "@/components/custom/navbar/Dropdown";
 import AppTabs from "@/components/custom/tabs/AppTabs";

--- a/src/pages/groups/groups-view/commitee-tab/GroupsAddRoleCommiteeTab.tsx
+++ b/src/pages/groups/groups-view/commitee-tab/GroupsAddRoleCommiteeTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/commitee-tab/GroupsCommiteeTab.tsx
+++ b/src/pages/groups/groups-view/commitee-tab/GroupsCommiteeTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/general-tab/GroupsGeneralTab.tsx
+++ b/src/pages/groups/groups-view/general-tab/GroupsGeneralTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/group-actions/AttachMeeting.tsx
+++ b/src/pages/groups/groups-view/group-actions/AttachMeeting.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/group-actions/EditGroups.tsx
+++ b/src/pages/groups/groups-view/group-actions/EditGroups.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/group-actions/ManageGroupMembers.tsx
+++ b/src/pages/groups/groups-view/group-actions/ManageGroupMembers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/group-actions/TransferClients.tsx
+++ b/src/pages/groups/groups-view/group-actions/TransferClients.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/groups/groups-view/notes-tab/GroupsNotesTab.tsx
+++ b/src/pages/groups/groups-view/notes-tab/GroupsNotesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import mifosLogo from '@/assets/images/image-removebg-preview-transparent.png';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/src/pages/home/dashboard/Dashboard.tsx
+++ b/src/pages/home/dashboard/Dashboard.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 

--- a/src/pages/home/dashboard/amount-collected-pie/AmountCollectedPie.tsx
+++ b/src/pages/home/dashboard/amount-collected-pie/AmountCollectedPie.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Pie, PieChart, Cell, Legend } from "recharts";
 

--- a/src/pages/home/dashboard/amount-disbursed-pie/AmountDisbursedPie.tsx
+++ b/src/pages/home/dashboard/amount-disbursed-pie/AmountDisbursedPie.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Pie, PieChart, Cell, Legend } from "recharts";
 

--- a/src/pages/home/dashboard/client-trends-bar/ClientTrendsBar.tsx
+++ b/src/pages/home/dashboard/client-trends-bar/ClientTrendsBar.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import {
     LineChart,

--- a/src/pages/loans/loans-view/LoansView.tsx
+++ b/src/pages/loans/loans-view/LoansView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Outlet, useParams } from "react-router-dom";
 

--- a/src/pages/loans/loans-view/account-details/LoansAccountDetails.tsx
+++ b/src/pages/loans/loans-view/account-details/LoansAccountDetails.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { LoansApi } from "@/fineract-api";

--- a/src/pages/loans/loans-view/external-asset-owner-tab/LoansExternalAssetOwnerTab.tsx
+++ b/src/pages/loans/loans-view/external-asset-owner-tab/LoansExternalAssetOwnerTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 const LoansExternalAssetOwnerTab = () => {
   return (

--- a/src/pages/loans/loans-view/general-tab/LoansGeneralTab.tsx
+++ b/src/pages/loans/loans-view/general-tab/LoansGeneralTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { LoansApi } from "@/fineract-api";

--- a/src/pages/loans/loans-view/loan-account-actions/add-collateral/AddCollateral.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/add-collateral/AddCollateral.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/add-interest-pause/AddInterestPause.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/add-interest-pause/AddInterestPause.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/add-loan-charge/AddLoanCharge.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/add-loan-charge/AddLoanCharge.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/loans/loans-view/loan-account-actions/approve-loan/ApproveLoan.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/approve-loan/ApproveLoan.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/assign-loan-officer/AssignLoanOfficer.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/assign-loan-officer/AssignLoanOfficer.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/charge-off/ChargeOff.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/charge-off/ChargeOff.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/close-as-rescheduled/CloseAsRescheduled.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/close-as-rescheduled/CloseAsRescheduled.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/create-guarantor/CreateGuarantor.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/create-guarantor/CreateGuarantor.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/disburse-to-savings-account/DisburseToSavingsAccount.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/disburse-to-savings-account/DisburseToSavingsAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/disburse/Disburse.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/disburse/Disburse.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/foreclosure/Foreclosure.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/foreclosure/Foreclosure.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/loan-reaging/LoanReaging.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/loan-reaging/LoanReaging.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/loan-reamortize/LoanReamortize.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/loan-reamortize/LoanReamortize.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/loan-reschedule/LoanReschedule.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/loan-reschedule/LoanReschedule.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/loan-screen-reports/LoanScreenReports.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/loan-screen-reports/LoanScreenReports.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 
 const LoanScreenReports = () => {

--- a/src/pages/loans/loans-view/loan-account-actions/loans-account-close/LoansAccountClose.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/loans-account-close/LoansAccountClose.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/make-repayment/MakeRepayment.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/make-repayment/MakeRepayment.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/loans/loans-view/loan-account-actions/prepay-loan/PrepayLoan.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/prepay-loan/PrepayLoan.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/sell-loan/SellLoan.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/sell-loan/SellLoan.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/undo-approval/UndoApproval.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/undo-approval/UndoApproval.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/undo-disbursal/UndoDisbursal.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/undo-disbursal/UndoDisbursal.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/view-guarantors/ViewGuarantors.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/view-guarantors/ViewGuarantors.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import {
   Table,

--- a/src/pages/loans/loans-view/loan-account-actions/waive-interest/WaiveInterest.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/waive-interest/WaiveInterest.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/withdraw-by-client/WithdrawByClient.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/withdraw-by-client/WithdrawByClient.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-account-actions/write-off-page/WriteOffPage.tsx
+++ b/src/pages/loans/loans-view/loan-account-actions/write-off-page/WriteOffPage.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/loans/loans-view/loan-collateral-tab/LoansCollateralTab.tsx
+++ b/src/pages/loans/loans-view/loan-collateral-tab/LoansCollateralTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 

--- a/src/pages/loans/loans-view/loan-delinquency-tags-tab/LoansDelinquencyTagsTab.tsx
+++ b/src/pages/loans/loans-view/loan-delinquency-tags-tab/LoansDelinquencyTagsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 const LoansDelinquencyTagsTab = () => {
   return (

--- a/src/pages/loans/loans-view/loan-documents-tab/LoansDocumentsTab.tsx
+++ b/src/pages/loans/loans-view/loan-documents-tab/LoansDocumentsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import {

--- a/src/pages/loans/loans-view/loan-term-variations-tab/LoansTermVariationsTab.tsx
+++ b/src/pages/loans/loans-view/loan-term-variations-tab/LoansTermVariationsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 const LoansTermVariationsTab = () => {
   return (

--- a/src/pages/loans/loans-view/notes-tab/LoansNotesTab.tsx
+++ b/src/pages/loans/loans-view/notes-tab/LoansNotesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/loans/loans-view/repayment-schedule-tab/LoansRepaymentScheduleTab.tsx
+++ b/src/pages/loans/loans-view/repayment-schedule-tab/LoansRepaymentScheduleTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { LoansApi } from "@/fineract-api";

--- a/src/pages/loans/loans-view/reschedule-loan-tab/LoansRescheduleLoanTab.tsx
+++ b/src/pages/loans/loans-view/reschedule-loan-tab/LoansRescheduleLoanTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 const LoansRescheduleLoanTab = () => {
   return (

--- a/src/pages/loans/loans-view/transactions/LoansTransactions.tsx
+++ b/src/pages/loans/loans-view/transactions/LoansTransactions.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { LoansApi } from "@/fineract-api";

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { loginUser } from "@/pages/login/loginSlice";

--- a/src/pages/login/loginApi.ts
+++ b/src/pages/login/loginApi.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import fineract from "@/lib/axios";
 
 export const loginFineract = async (username: string, password: string) => {

--- a/src/pages/login/loginSlice.ts
+++ b/src/pages/login/loginSlice.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { loginFineract } from "@/pages/login/loginApi";
 

--- a/src/pages/navigation/Navigation.tsx
+++ b/src/pages/navigation/Navigation.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import fineract from "@/lib/axios";
 

--- a/src/pages/navigation/center-navigation/CenterNavigation.tsx
+++ b/src/pages/navigation/center-navigation/CenterNavigation.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import fineract from "@/lib/axios";
 import { faBuilding, faCircle } from "@fortawesome/free-solid-svg-icons";

--- a/src/pages/navigation/client-navigation/ClientNavigation.tsx
+++ b/src/pages/navigation/client-navigation/ClientNavigation.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser, faCircle } from "@fortawesome/free-solid-svg-icons";

--- a/src/pages/navigation/group-navigation/GroupNavigation.tsx
+++ b/src/pages/navigation/group-navigation/GroupNavigation.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUsers, faCircle } from "@fortawesome/free-solid-svg-icons";

--- a/src/pages/navigation/office-navigation/OfficeNavigation.tsx
+++ b/src/pages/navigation/office-navigation/OfficeNavigation.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { OfficesApi, StaffApi, type GetOfficesResponse } from "@/fineract-api";
 import { getConfiguration } from "@/lib/fineract-openapi";
 import { faBuilding } from "@fortawesome/free-solid-svg-icons";

--- a/src/pages/navigation/staff-navigation/StaffNavigation.tsx
+++ b/src/pages/navigation/staff-navigation/StaffNavigation.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser, faCircle } from "@fortawesome/free-solid-svg-icons";
 import { useEffect, useState } from "react";

--- a/src/pages/not-found/NotFound.tsx
+++ b/src/pages/not-found/NotFound.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { useNavigate } from "react-router-dom";

--- a/src/pages/notifications/Notifications.tsx
+++ b/src/pages/notifications/Notifications.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import {
   Select,
   SelectContent,

--- a/src/pages/organization/Organization.tsx
+++ b/src/pages/organization/Organization.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate } from "react-router-dom";
 
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/organization/adhoc-query/AdhocQuery.tsx
+++ b/src/pages/organization/adhoc-query/AdhocQuery.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/adhoc-query/CreateAdhocQuery.tsx
+++ b/src/pages/organization/adhoc-query/CreateAdhocQuery.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/adhoc-query/EditAdhocQuery.tsx
+++ b/src/pages/organization/adhoc-query/EditAdhocQuery.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs"
 
 

--- a/src/pages/organization/adhoc-query/ViewAdhocQuery.tsx
+++ b/src/pages/organization/adhoc-query/ViewAdhocQuery.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/organization/bulk-loan-reassignmnet/BulkLoanReassignmnet.tsx
+++ b/src/pages/organization/bulk-loan-reassignmnet/BulkLoanReassignmnet.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/currencies/Currencies.tsx
+++ b/src/pages/organization/currencies/Currencies.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/currencies/ManageCurrencies.tsx
+++ b/src/pages/organization/currencies/ManageCurrencies.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import AppSelect from "@/components/custom/select/AppSelect";

--- a/src/pages/organization/employees/CreateEmployees.tsx
+++ b/src/pages/organization/employees/CreateEmployees.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Input } from "@/components/ui/input";

--- a/src/pages/organization/employees/EditEmployees.tsx
+++ b/src/pages/organization/employees/EditEmployees.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/organization/employees/Employees.tsx
+++ b/src/pages/organization/employees/Employees.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/employees/ViewEmployees.tsx
+++ b/src/pages/organization/employees/ViewEmployees.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/organization/holidays/EditHolidays.tsx
+++ b/src/pages/organization/holidays/EditHolidays.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/organization/holidays/Holidays.tsx
+++ b/src/pages/organization/holidays/Holidays.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/holidays/ManageHolidays.tsx
+++ b/src/pages/organization/holidays/ManageHolidays.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/holidays/ViewHolidays.tsx
+++ b/src/pages/organization/holidays/ViewHolidays.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { faLockOpen, faPenToSquare, faTrash } from "@fortawesome/free-solid-svg-icons";

--- a/src/pages/organization/investors/Investors.tsx
+++ b/src/pages/organization/investors/Investors.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";

--- a/src/pages/organization/manage-funds/CreateFunds.tsx
+++ b/src/pages/organization/manage-funds/CreateFunds.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/manage-funds/EditFunds.tsx
+++ b/src/pages/organization/manage-funds/EditFunds.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/organization/manage-funds/ManageFunds.tsx
+++ b/src/pages/organization/manage-funds/ManageFunds.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/manage-funds/ViewFunds.tsx
+++ b/src/pages/organization/manage-funds/ViewFunds.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/pages/organization/offices/CreateOffices.tsx
+++ b/src/pages/organization/offices/CreateOffices.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/offices/EditOffices.tsx
+++ b/src/pages/organization/offices/EditOffices.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/organization/offices/Offices.tsx
+++ b/src/pages/organization/offices/Offices.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/offices/ViewOffices.tsx
+++ b/src/pages/organization/offices/ViewOffices.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/organization/payment-types/CreatePaymentTypes.tsx
+++ b/src/pages/organization/payment-types/CreatePaymentTypes.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/payment-types/PaymentTypes.tsx
+++ b/src/pages/organization/payment-types/PaymentTypes.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/tellers/CreateTellers.tsx
+++ b/src/pages/organization/tellers/CreateTellers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/tellers/EditTellers.tsx
+++ b/src/pages/organization/tellers/EditTellers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/organization/tellers/Tellers.tsx
+++ b/src/pages/organization/tellers/Tellers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/organization/tellers/ViewTellers.tsx
+++ b/src/pages/organization/tellers/ViewTellers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/organization/working-days/WorkingDays.tsx
+++ b/src/pages/organization/working-days/WorkingDays.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Button } from "@/components/ui/button";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import AppSelect from "@/components/custom/select/AppSelect";

--- a/src/pages/products/Products.tsx
+++ b/src/pages/products/Products.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import {
   faBriefcase,

--- a/src/pages/products/charges/Charges.tsx
+++ b/src/pages/products/charges/Charges.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/charges/EditCharges.tsx
+++ b/src/pages/products/charges/EditCharges.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/products/charges/ViewCharges.tsx
+++ b/src/pages/products/charges/ViewCharges.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/products/collaterals/Collaterals.tsx
+++ b/src/pages/products/collaterals/Collaterals.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/collaterals/CreateCollaterals.tsx
+++ b/src/pages/products/collaterals/CreateCollaterals.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/collaterals/EditCollaterals.tsx
+++ b/src/pages/products/collaterals/EditCollaterals.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/products/collaterals/ViewCollaterals.tsx
+++ b/src/pages/products/collaterals/ViewCollaterals.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/products/fixed-deposit-products/FixedDepositProducts.tsx
+++ b/src/pages/products/fixed-deposit-products/FixedDepositProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/fixed-deposit-products/ViewFixedDepositProducts.tsx
+++ b/src/pages/products/fixed-deposit-products/ViewFixedDepositProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/products/floating-rates/FloatingRates.tsx
+++ b/src/pages/products/floating-rates/FloatingRates.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/floating-rates/ViewFloatingRates.tsx
+++ b/src/pages/products/floating-rates/ViewFloatingRates.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs"
 import { Separator } from "@/components/ui/separator"
 import { FloatingRatesApi, type FloatingRateData } from "@/fineract-api"

--- a/src/pages/products/loan-products/LoanProducts.tsx
+++ b/src/pages/products/loan-products/LoanProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/loan-products/ViewLoanProducts.tsx
+++ b/src/pages/products/loan-products/ViewLoanProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 

--- a/src/pages/products/loan-products/create-loan-products/CreateLoanProducts.tsx
+++ b/src/pages/products/loan-products/create-loan-products/CreateLoanProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import AppStepper from "@/components/custom/stepper/AppStepper";
 import {

--- a/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductAccountingStep.tsx
+++ b/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductAccountingStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 

--- a/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductChargesStep.tsx
+++ b/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductChargesStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";

--- a/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductCurrencyStep.tsx
+++ b/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductCurrencyStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 

--- a/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductDetailsStep.tsx
+++ b/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductDetailsStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";

--- a/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductSettingsStep.tsx
+++ b/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductSettingsStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";

--- a/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductTermsStep.tsx
+++ b/src/pages/products/loan-products/create-loan-products/create-loan-products-stepper/LoanProductTermsStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";

--- a/src/pages/products/manage-delinquency-buckets/ManageDeliquencyBuckets.tsx
+++ b/src/pages/products/manage-delinquency-buckets/ManageDeliquencyBuckets.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate } from "react-router-dom"
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs"
 

--- a/src/pages/products/manage-delinquency-buckets/delinquency-bucket/CreateDelinquencyBucket.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-bucket/CreateDelinquencyBucket.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Trash2 } from "lucide-react";

--- a/src/pages/products/manage-delinquency-buckets/delinquency-bucket/DelinquencyBucket.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-bucket/DelinquencyBucket.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/manage-delinquency-buckets/delinquency-bucket/EditDelinquencyBucket.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-bucket/EditDelinquencyBucket.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Trash2 } from "lucide-react";

--- a/src/pages/products/manage-delinquency-buckets/delinquency-bucket/ViewDelinquencyBucket.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-bucket/ViewDelinquencyBucket.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import {

--- a/src/pages/products/manage-delinquency-buckets/delinquency-range/CreateDelinquencyRange.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-range/CreateDelinquencyRange.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/manage-delinquency-buckets/delinquency-range/DelinquencyRange.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-range/DelinquencyRange.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/manage-delinquency-buckets/delinquency-range/EditDelinquencyRange.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-range/EditDelinquencyRange.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/products/manage-delinquency-buckets/delinquency-range/ViewDelinquencyRange.tsx
+++ b/src/pages/products/manage-delinquency-buckets/delinquency-range/ViewDelinquencyRange.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {

--- a/src/pages/products/manage-tax-configurations/ManageTaxConfigurations.tsx
+++ b/src/pages/products/manage-tax-configurations/ManageTaxConfigurations.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/manage-tax-configurations/manage-tax-components/ManageTaxComponents.tsx
+++ b/src/pages/products/manage-tax-configurations/manage-tax-components/ManageTaxComponents.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/manage-tax-configurations/manage-tax-groups/ManageTaxGroups.tsx
+++ b/src/pages/products/manage-tax-configurations/manage-tax-groups/ManageTaxGroups.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/products-mix/ProductsMix.tsx
+++ b/src/pages/products/products-mix/ProductsMix.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/recurring-deposit-products/RecurringDepositProducts.tsx
+++ b/src/pages/products/recurring-deposit-products/RecurringDepositProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/recurring-deposit-products/ViewRecurringDepositProducts.tsx
+++ b/src/pages/products/recurring-deposit-products/ViewRecurringDepositProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/products/savings-products/SavingsProducts.tsx
+++ b/src/pages/products/savings-products/SavingsProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/products/savings-products/ViewSavingsProducts.tsx
+++ b/src/pages/products/savings-products/ViewSavingsProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/products/savings-products/create-saving-products/CreateSavingsProducts.tsx
+++ b/src/pages/products/savings-products/create-saving-products/CreateSavingsProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {

--- a/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductAccountingStep.tsx
+++ b/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductAccountingStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 

--- a/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductChargesStep.tsx
+++ b/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductChargesStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Trash } from "lucide-react";

--- a/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductCurrencyStep.tsx
+++ b/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductCurrencyStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import AppSelect from "@/components/custom/select/AppSelect";

--- a/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductDetailsStep.tsx
+++ b/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductDetailsStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 

--- a/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductSettingsStep.tsx
+++ b/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductSettingsStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";

--- a/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductTermsStep.tsx
+++ b/src/pages/products/savings-products/create-saving-products/create-saving-products-stepper/SavingsProductTermsStep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import AppSelect from "@/components/custom/select/AppSelect";

--- a/src/pages/products/share-products/ShareProducts.tsx
+++ b/src/pages/products/share-products/ShareProducts.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Button } from "@/components/ui/button";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 

--- a/src/pages/reports/Reports.tsx
+++ b/src/pages/reports/Reports.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/saving-product/saving-account-actions/activate-savings-account/ActivateSavingsAccount.tsx
+++ b/src/pages/saving-product/saving-account-actions/activate-savings-account/ActivateSavingsAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-account-actions/add-charge-savings-account/AddChargeSavingsAccount.tsx
+++ b/src/pages/saving-product/saving-account-actions/add-charge-savings-account/AddChargeSavingsAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-account-actions/approve-savings-account/ApproveSavingAccount.tsx
+++ b/src/pages/saving-product/saving-account-actions/approve-savings-account/ApproveSavingAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-account-actions/manage-savings-account/ManageSavingsAccount.tsx
+++ b/src/pages/saving-product/saving-account-actions/manage-savings-account/ManageSavingsAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-account-actions/reject-savings-account/RejectSavingsAccount.tsx
+++ b/src/pages/saving-product/saving-account-actions/reject-savings-account/RejectSavingsAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-account-actions/savings-account-assign-staff/SavingsAccountAssignStaff.tsx
+++ b/src/pages/saving-product/saving-account-actions/savings-account-assign-staff/SavingsAccountAssignStaff.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-account-actions/savings-account-transactions/SavingsAccountTransactions.tsx
+++ b/src/pages/saving-product/saving-account-actions/savings-account-transactions/SavingsAccountTransactions.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-account-actions/undo-approval-savings-account/UndoApprovalSavingsAccount.tsx
+++ b/src/pages/saving-product/saving-account-actions/undo-approval-savings-account/UndoApprovalSavingsAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-product-view/SavingProductView.tsx
+++ b/src/pages/saving-product/saving-product-view/SavingProductView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Outlet, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-product-view/charges-tab/SavingProductChargesTab.tsx
+++ b/src/pages/saving-product/saving-product-view/charges-tab/SavingProductChargesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-product-view/general-tab/SavingProductGeneralTab.tsx
+++ b/src/pages/saving-product/saving-product-view/general-tab/SavingProductGeneralTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-product-view/notes-tab/SavingsNotesTab.tsx
+++ b/src/pages/saving-product/saving-product-view/notes-tab/SavingsNotesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-product-view/savings-documents-tab/SavingsDocumentsTab.tsx
+++ b/src/pages/saving-product/saving-product-view/savings-documents-tab/SavingsDocumentsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/saving-product/saving-product-view/transaction-tab/SavingProductTransactionTab.tsx
+++ b/src/pages/saving-product/saving-product-view/transaction-tab/SavingProductTransactionTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import {
   Accordion,

--- a/src/pages/shares/shares-account-actions/activate-shares-account/ActivateSharesAccount.tsx
+++ b/src/pages/shares/shares-account-actions/activate-shares-account/ActivateSharesAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-actions/apply-shares/ApplyShares.tsx
+++ b/src/pages/shares/shares-account-actions/apply-shares/ApplyShares.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-actions/approve-shares-account/ApproveSharesAccount.tsx
+++ b/src/pages/shares/shares-account-actions/approve-shares-account/ApproveSharesAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-actions/close-shares-account/CloseSharesAccount.tsx
+++ b/src/pages/shares/shares-account-actions/close-shares-account/CloseSharesAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-actions/redeem-shares/RedeemShares.tsx
+++ b/src/pages/shares/shares-account-actions/redeem-shares/RedeemShares.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-actions/reject-shares-account/RejectSharesAccount.tsx
+++ b/src/pages/shares/shares-account-actions/reject-shares-account/RejectSharesAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-actions/undo-approval-shares-account/UndoApprovalSharesAccount.tsx
+++ b/src/pages/shares/shares-account-actions/undo-approval-shares-account/UndoApprovalSharesAccount.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate, useParams } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import { Button } from "@/components/ui/button";

--- a/src/pages/shares/shares-account-view/SharesAccountView.tsx
+++ b/src/pages/shares/shares-account-view/SharesAccountView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Outlet, useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-view/charges-tab/SharesAccountChargesTab.tsx
+++ b/src/pages/shares/shares-account-view/charges-tab/SharesAccountChargesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-view/dividends-tab/SharesAccountDividendesTab.tsx
+++ b/src/pages/shares/shares-account-view/dividends-tab/SharesAccountDividendesTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-view/general-tab/SharesAccountGeneralTab.tsx
+++ b/src/pages/shares/shares-account-view/general-tab/SharesAccountGeneralTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 

--- a/src/pages/shares/shares-account-view/transactions-tab/SharesAccountTransactionsTab.tsx
+++ b/src/pages/shares/shares-account-view/transactions-tab/SharesAccountTransactionsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/system/System.tsx
+++ b/src/pages/system/System.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useNavigate } from "react-router-dom";
 
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";

--- a/src/pages/system/account-number-preferences/AccountNumberPreferences.tsx
+++ b/src/pages/system/account-number-preferences/AccountNumberPreferences.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";

--- a/src/pages/system/account-number-preferences/CreateAccountNumberPreferences.tsx
+++ b/src/pages/system/account-number-preferences/CreateAccountNumberPreferences.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/system/account-number-preferences/ViewAccountNumberPreferences.tsx
+++ b/src/pages/system/account-number-preferences/ViewAccountNumberPreferences.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/system/codes/Codes.tsx
+++ b/src/pages/system/codes/Codes.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";

--- a/src/pages/system/codes/ViewCodes.tsx
+++ b/src/pages/system/codes/ViewCodes.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"

--- a/src/pages/system/configurations/Configurations.tsx
+++ b/src/pages/system/configurations/Configurations.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import { Input } from "@/components/ui/input";

--- a/src/pages/system/entity-to-entity-mapping/EntityToEntityMapping.tsx
+++ b/src/pages/system/entity-to-entity-mapping/EntityToEntityMapping.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 
 const EntityToEntityMapping = () => {

--- a/src/pages/system/manage-data-tables/ManageDataTables.tsx
+++ b/src/pages/system/manage-data-tables/ManageDataTables.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/system/manage-data-tables/ViewDataTables.tsx
+++ b/src/pages/system/manage-data-tables/ViewDataTables.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/src/pages/system/manage-external-events/ManageExternalEvents.tsx
+++ b/src/pages/system/manage-external-events/ManageExternalEvents.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 import { Input } from "@/components/ui/input";

--- a/src/pages/system/manage-hooks/ManageHooks.tsx
+++ b/src/pages/system/manage-hooks/ManageHooks.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";

--- a/src/pages/system/manage-reports/ManageReports.tsx
+++ b/src/pages/system/manage-reports/ManageReports.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";

--- a/src/pages/system/manage-reports/ViewReports.tsx
+++ b/src/pages/system/manage-reports/ViewReports.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/system/roles-and-permissions/CreateRolesAndPermissions.tsx
+++ b/src/pages/system/roles-and-permissions/CreateRolesAndPermissions.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/system/roles-and-permissions/RolesAndPermissions.tsx
+++ b/src/pages/system/roles-and-permissions/RolesAndPermissions.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus, PenSquare } from "lucide-react";

--- a/src/pages/tasks/checker-inbox-and-tasks-tabs/checker-inbox/CheckerInbox.tsx
+++ b/src/pages/tasks/checker-inbox-and-tasks-tabs/checker-inbox/CheckerInbox.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/tasks/checker-inbox-and-tasks-tabs/client-approval/ClientApproval.tsx
+++ b/src/pages/tasks/checker-inbox-and-tasks-tabs/client-approval/ClientApproval.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/tasks/checker-inbox-and-tasks-tabs/loan-approval/LoanApproval.tsx
+++ b/src/pages/tasks/checker-inbox-and-tasks-tabs/loan-approval/LoanApproval.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/LoanDisbursal.tsx
+++ b/src/pages/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/LoanDisbursal.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/RescheduleLoan.tsx
+++ b/src/pages/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/RescheduleLoan.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/tasks/checker-inbox-and-tasks/CheckerInBoxAndTasks.tsx
+++ b/src/pages/tasks/checker-inbox-and-tasks/CheckerInBoxAndTasks.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { NavLink, Outlet } from "react-router-dom";
 import { AppBreadCrumbs } from "@/components/custom/breadcrumbs/AppBreadCrumbs";
 

--- a/src/pages/templates/Templates.tsx
+++ b/src/pages/templates/Templates.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import {
     Table,
     TableBody,

--- a/src/pages/users/CreateUsers.tsx
+++ b/src/pages/users/CreateUsers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/users/EditUsers.tsx
+++ b/src/pages/users/EditUsers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from "react"; // react hooks
 import { useNavigate } from "react-router-dom"; // for navigation
 

--- a/src/pages/users/ViewUsers.tsx
+++ b/src/pages/users/ViewUsers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 

--- a/src/router/AppRoutes.tsx
+++ b/src/router/AppRoutes.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import Home from '@/pages/home/Home'
 import Layout from '@/layout/Layout'
 import Login from '@/pages/login/Login'

--- a/src/router/ProtectedRoutes.tsx
+++ b/src/router/ProtectedRoutes.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import { Outlet, Navigate } from "react-router-dom";
 
 const ProtectedRoutes = () => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 /// <reference types="vite/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import path from "path";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";


### PR DESCRIPTION
This pr add MPL license headers to all source files

[MXWAR-34](https://mifosforge.jira.com/browse/MXWAR-34)

<img width="1443" height="606" alt="image" src="https://github.com/user-attachments/assets/d62d31cb-46be-476f-bdd8-029c48ad1bca" />


[MXWAR-34]: https://mifosforge.jira.com/browse/MXWAR-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ