### PR TITLE
MXWAR-35:add GitHub PR template for standardized contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+
+Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.
+
+## Related issues and discussion
+
+#{Issue Number}
+
+## Screenshots, if any
+
+## Checklist
+
+Please make sure these boxes are checked before submitting your pull request - thanks!
+
+- [ ] If you have multiple commits please combine them into one commit by squashing them.
+
+- [ ] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


### PR DESCRIPTION
This pr added a GitHub Pull Request template to standardize PR submissions across the repository. The template includes sections for description, related issues, screenshots, and a contribution checklist.
This matches the template format used in the original web-app repository

[MXWAR-35](https://mifosforge.jira.com/browse/MXWAR-35)

[MXWAR-35]: https://mifosforge.jira.com/browse/MXWAR-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ