### PR TITLE
UI: Update login placeholder from Email to Username/Email for better UX.

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -144,7 +144,7 @@ const Login = () => {
               value={form.username}
               onChange={handleChange}
               type="text"
-              placeholder="Email"
+              placeholder="Username / Email"
               className="dark:bg-zinc-800 dark:text-white mb-4"
             />
 


### PR DESCRIPTION

![email- before mifos](https://github.com/user-attachments/assets/d99e7256-a645-4b6c-9d62-53968670593c)
As part of the WEB-114 modernization and UX improvement, I've updated the login input placeholder. The system currently accepts a username (mifos), but the label previously said 'Email,' which could be confusing for new users. Updated it to 'Username / Email' for better clarity.
![username-email changes after](https://github.com/user-attachments/assets/922d201f-ba37-4ade-89af-19ed7f55b417)
