### PR TITLE
MXWAR-46: Fix 404 error when navigating to individual report run view

### DIFF
--- a/src/router/AppRoutes.tsx
+++ b/src/router/AppRoutes.tsx
@@ -347,9 +347,12 @@ const AppRoutes = () => {
           </Route>
 
           {/* Reports */}
-          <Route path="/reports" element={<Reports />} />
-          <Route path="/reports/:category" element={<Reports />} />
-
+          <Route path='/reports/run/:reportName' element={<Reports />} />
+          <Route path='/reports/:category' element={<Reports />} />
+          <Route path='/reports' element={<Reports />} />
+          
+          
+          
           {/* Admin Routes */}
 
           {/* User */}


### PR DESCRIPTION
**`MXWAR-46`**: Fix 404 error when navigating to individual report run view


Problem: > Clicking on an individual report name (e.g., "Client Listing") from the reports list results in a 404 "Page Not Found" error.

BEFORE CHANGES

https://github.com/user-attachments/assets/2d716235-a12d-4a79-b98b-48811aba6d19


Root Cause: The Reports.tsx component navigates to /reports/run/:reportName, but this path was not defined in AppRoutes.tsx. This caused the router to hit the catch-all * (NotFound) route.


Changes Made:
Added the missing dynamic route /reports/run/:reportName to AppRoutes.tsx.

Reordered the report routes to ensure specific paths are prioritized over generic category parameters to prevent routing conflicts.

Validation: Verified that the 404 page no longer appears when clicking a report name. The app now remains on the Reports page with the correct URL structure.

AFTER CHANGES

https://github.com/user-attachments/assets/f93d6e66-17bf-44f5-a883-02999e175880



