### PR TITLE
MXWAR-38 fix(login): swap login logo for dark mode to improve contrast

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -11,7 +11,8 @@ import { loginUser } from '@/pages/login/loginSlice'
 import { type RootState, type AppDispatch } from '@/app/store'
 
 import mainImg from '@/assets/images/cover_image_resized.webp'
-import mifosLogo from '@/assets/images/mifos_lg-logo.png'
+import mifosLogoLight from '@/assets/images/mifos_lg-logo.png'
+import mifosLogoDark from '@/assets/images/image-removebg-preview-transparent.png'
 
 import { Sun, Moon } from 'lucide-react'
 
@@ -157,7 +158,11 @@ const Login = () => {
         </div>
 
         <div className="lg:h-[90%] flex flex-col items-center w-full max-w-md mx-auto">
-          <img src={mifosLogo} alt="mifosLogo" className="h-[130px] m-6" />
+          <img
+            src={theme === 'dark' ? mifosLogoDark : mifosLogoLight}
+            alt="mifosLogo"
+            className="h-[130px] m-6"
+          />
 
           <Select>
             <SelectTrigger className="w-full max-w-xs">


### PR DESCRIPTION
Swaps the login logo based on theme so the logo remains readable and visually consistent in dark mode. The login now displays the existing dark-on-light logo in light theme and a transparent / light-colored logo in dark theme to avoid low contrast and visible background artifacts. This improves UI accessibility and visual polish on the login screen.

[MXWAR-38](https://mifosforge.jira.com/browse/MXWAR-38)

Before:
<img width="569" height="971" alt="image" src="https://github.com/user-attachments/assets/db6811b8-2d9f-4b3f-a006-59dcc57f14f7" />
After:
<img width="576" height="975" alt="image" src="https://github.com/user-attachments/assets/8c6fe525-d77f-4680-97d7-0087d7fc755f" />



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-38]: https://mifosforge.jira.com/browse/MXWAR-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ