### PR TITLE
Fix Date Formatting on Office and Holiday pages

### DIFF
--- a/src/pages/organization/holidays/Holidays.tsx
+++ b/src/pages/organization/holidays/Holidays.tsx
@@ -29,6 +29,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { format } from 'date-fns'
 
 const holidayApi = new HolidaysApi(getConfiguration())
 const officesApi = new OfficesApi(getConfiguration())
@@ -151,13 +152,42 @@ const Holidays = () => {
                       {holiday.name || '—'}
                     </TableCell>
                     <TableCell className="px-6 py-4">
-                      {holiday.fromDate}
+                      {Array.isArray(holiday.fromDate)
+                        ? format(
+                          new Date(
+                            holiday.fromDate[0],
+                            holiday.fromDate[1] - 1,
+                            holiday.fromDate[2]
+                          ),
+                          'dd MMMM yyyy'
+                        )
+                        : '—'}
                     </TableCell>
+
                     <TableCell className="px-6 py-4">
-                      {holiday.toDate}
+                      {Array.isArray(holiday.toDate)
+                        ? format(
+                          new Date(
+                            holiday.toDate[0],
+                            holiday.toDate[1] - 1,
+                            holiday.toDate[2]
+                          ),
+                          'dd MMMM yyyy'
+                        )
+                        : '—'}
                     </TableCell>
+
                     <TableCell className="px-6 py-4">
-                      {holiday.repaymentsRescheduledTo}
+                      {Array.isArray(holiday.repaymentsRescheduledTo)
+                        ? format(
+                          new Date(
+                            holiday.repaymentsRescheduledTo[0],
+                            holiday.repaymentsRescheduledTo[1] - 1,
+                            holiday.repaymentsRescheduledTo[2]
+                          ),
+                          'dd MMMM yyyy'
+                        )
+                        : '—'}
                     </TableCell>
                     <TableCell className="px-6 py-4">
                       {holiday.status?.value || '—'}

--- a/src/pages/organization/holidays/ViewHolidays.tsx
+++ b/src/pages/organization/holidays/ViewHolidays.tsx
@@ -29,6 +29,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { format } from 'date-fns'
 
 const holidayApi = new HolidaysApi(getConfiguration())
 
@@ -163,13 +164,46 @@ const ViewHolidays = () => {
           <div>{holiday?.name || '—'}</div>
 
           <div className="font-medium">From Date</div>
-          <div>{holiday?.fromDate}</div>
+          <div>
+            {Array.isArray(holiday?.fromDate)
+              ? format(
+                new Date(
+                  holiday.fromDate[0],
+                  holiday.fromDate[1] - 1,
+                  holiday.fromDate[2]
+                ),
+                'dd MMMM yyyy'
+              )
+              : '—'}
+          </div>
 
           <div className="font-medium">To Date</div>
-          <div>{holiday?.toDate}</div>
+          <div>
+            {Array.isArray(holiday?.toDate)
+              ? format(
+                new Date(
+                  holiday.toDate[0],
+                  holiday.toDate[1] - 1,
+                  holiday.toDate[2]
+                ),
+                'dd MMMM yyyy'
+              )
+              : '—'}
+          </div>
 
           <div className="font-medium">Repayments Scheduled To</div>
-          <div>{holiday?.repaymentsRescheduledTo}</div>
+          <div>
+            {Array.isArray(holiday?.repaymentsRescheduledTo)
+              ? format(
+                new Date(
+                  holiday.repaymentsRescheduledTo[0],
+                  holiday.repaymentsRescheduledTo[1] - 1,
+                  holiday.repaymentsRescheduledTo[2]
+                ),
+                'dd MMMM yyyy'
+              )
+              : '—'}
+          </div>
         </div>
 
         {/* Back button */}

--- a/src/pages/organization/offices/Offices.tsx
+++ b/src/pages/organization/offices/Offices.tsx
@@ -32,6 +32,7 @@ import { OfficesApi, type GetOfficesResponse } from '@/fineract-api'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Plus, Upload } from 'lucide-react'
+import { format } from 'date-fns'
 
 const officesApi = new OfficesApi(getConfiguration())
 
@@ -179,7 +180,16 @@ const Offices = () => {
                   {'Missing in OpenApi'}
                 </TableCell>
                 <TableCell className="px-6 py-4 text-zinc-700 dark:text-zinc-200">
-                  {office.openingDate || '—'}
+                  {Array.isArray(office.openingDate)
+                    ? format(
+                      new Date(
+                        office.openingDate[0],
+                        office.openingDate[1] - 1,
+                        office.openingDate[2]
+                      ),
+                      'dd MMMM yyyy'
+                    )
+                    : '—'}
                 </TableCell>
               </TableRow>
             ))}


### PR DESCRIPTION
**JIRA TICKET:** [MXWAR-51](https://mifosforge.jira.com/browse/MXWAR-51)
## Description

Wrong date formatting in Manage Offices and Manage Holidays pages, as well as the viewing pages.
**Office page**

<img width="1440" height="376" alt="image" src="https://github.com/user-attachments/assets/f42113a5-762f-4115-91cb-fcf04759f757" />

**Holiday Pages**
<img width="1440" height="163" alt="image" src="https://github.com/user-attachments/assets/ea82fdab-39c9-4cb5-88ac-1353deba1c6e" />

<img width="874" height="517" alt="image" src="https://github.com/user-attachments/assets/15095f1c-1506-43d1-aebe-3c733072a41e" />
 
 
 
**After**
<img width="1498" height="433" alt="image" src="https://github.com/user-attachments/assets/6d0b6676-58a1-4e1f-ac19-3856a764caa6" />
<img width="1512" height="173" alt="image" src="https://github.com/user-attachments/assets/bb2755b2-6a3e-4c5b-8550-c2165d9f32e6" />
<img width="860" height="495" alt="image" src="https://github.com/user-attachments/assets/f87ee025-c119-47fd-bb7a-a8b08052c191" />




Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-51]: https://mifosforge.jira.com/browse/MXWAR-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ