### PR TITLE
MXWAR-55 fix: update Docker Hub workflow trigger branch from develop …

### DIFF
--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -2,7 +2,7 @@
 # Publish Mifos X React Web App to Docker Hub
 # =============================================================================
 # Triggers on:
-#   - Push to 'develop' branch  → tags: develop, <short-sha>, <long-sha>
+#   - Push to 'dev' branch  → tags: dev, <short-sha>, <long-sha>
 #   - Semver tag push (v*.*.*)  → tags: <version>, latest
 #
 # Secrets required in the repository:
@@ -15,7 +15,7 @@ name: Publish to Docker Hub
 on:
   push:
     branches:
-      - develop
+      - dev
     tags:
       - "v*.*.*"
 
@@ -39,7 +39,7 @@ jobs:
         with:
           images: mifos/web-app-react
           tags: |
-            # On develop branch: tag as "develop" + git sha
+            # On dev branch: tag as "dev" + git sha
             type=ref,event=branch
             type=sha,prefix=,format=short
             type=sha,prefix=,format=long


### PR DESCRIPTION
…to dev

The publish-dockerhub workflow was updated to trigger on pushes to the dev branch instead of the develop branch. This change aligns the workflow with the default branch of the repository, ensuring that Docker images are built and published correctly.


[MXWAR-55](https://mifosforge.jira.com/browse/MXWAR-55)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-55]: https://mifosforge.jira.com/browse/MXWAR-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ