### PR TITLE
MXWAR-56: Fix Docker Image publishing in Mifos's DockerHub Account

### DIFF
--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -37,7 +37,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: mifos/web-app-react
+          images: openmf/web-app-react
           tags: |
             # On dev branch: tag as "dev" + git sha
             type=ref,event=branch


### PR DESCRIPTION
Updated the Docker metadata image name in publish-dockerhub.yml from mifos/web-app-react to openmf/web-app-react.

[MXWAR-56](https://mifosforge.jira.com/browse/MXWAR-56)
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-56]: https://mifosforge.jira.com/browse/MXWAR-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ