### PR TITLE
Add manual Fineract setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The application uses environment variables for configuration. Copy `.env.sample`
 
 If running Apache Fineract manually (e.g., on `https://localhost:8443`):
 
-1. Create a file: ```.env.development.local```
+1. Create a file: `.env.development.local`
 
 
 2. Add the below configurations

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ For Docker environment variables, see `.env.docker.sample`.
 
 ## �🔧 Environment Variables
 
-The application uses environment variables for configuration. Copy `.env.sample` to `.env` or `.env.local` and adjust the values as needed.
+The application uses environment variables for configuration. Copy `.env.sample` to `.env` or `.env.development.local` and adjust the values as needed.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -152,19 +152,25 @@ The application uses environment variables for configuration. Copy `.env.sample`
 | `VITE_FINERACT_API_VERSION` | API version path | `/api` |
 | `VITE_FINERACT_PLATFORM_TENANT_IDENTIFIER` | Tenant identifier for multi-tenant deployments | `default` |
 
-### Example Configuration
+### Manual Fineract Setup (Without Docker)
+
+If running Apache Fineract manually (e.g., on `https://localhost:8443`):
+
+1. Create a file: ```.env.development.local```
+
+
+2. Add the below configurations
 
 ```bash
-# .env.local
+# .env.development.local
 VITE_FINERACT_API_URL=https://localhost:8443
 VITE_FINERACT_API_PROVIDER=/fineract-provider
 VITE_FINERACT_API_VERSION=/api
 VITE_FINERACT_PLATFORM_TENANT_IDENTIFIER=default
+VITE_FINERACT_PLUGIN_OIDC_ENABLED=false
 ```
 
 > **Note:** Files ending in `.local` are ignored by git and should be used for machine-specific configuration.
-
-For detailed documentation of all available variables, see [.env.sample](./.env.sample).
 
 ---
 


### PR DESCRIPTION
JIRA TICKET: [MXWAR-58](https://mifosforge.jira.com/browse/MXWAR-58)

## Description

Adds documentation clarifying environment variable precedence in development mode.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-58]: https://mifosforge.jira.com/browse/MXWAR-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded setup docs with a new manual (non-Docker) configuration section.
  * Updated guidance to use a development-local environment file for local setups.
  * Introduced documentation for a new flag to disable the OIDC plugin.
  * Noted that machine-specific “*.local” files are ignored by version control and removed references to the previous sample env guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->