### PR TITLE
MXWAR-61 :- Notifications feature

### DIFF
--- a/src/components/custom/navbar/MfNavbar.tsx
+++ b/src/components/custom/navbar/MfNavbar.tsx
@@ -8,6 +8,7 @@
 import { SidebarTrigger } from '@/components/ui/sidebar'
 
 import DropDown from '@/components/custom/navbar/Dropdown'
+import NotificationTray from '@/components/custom/navbar/NotificationTray'
 
 import {
   Landmark,
@@ -15,7 +16,6 @@ import {
   ChartBar,
   Shield,
   Search,
-  Bell,
   Moon,
   User,
   Sun,
@@ -120,12 +120,7 @@ const MfNavbar = () => {
           <Search className="w-5 h-5" />
         </button>
         <LanguageSwitcher className="w-[130px] bg-[#1074b9] border-white text-white hover:bg-[#0e6aa5]" />
-        <Button
-          variant="ghost"
-          className="hover:text-gray-200 transition-colors hover:bg-transparent dark:hover:bg-transparent cursor-pointer"
-        >
-          <Bell className="w-5 h-5" />
-        </Button>
+        <NotificationTray />
         <Button
           variant="ghost"
           className="hover:text-gray-200 transition-colors hover:bg-transparent dark:hover:bg-transparent cursor-pointer"

--- a/src/components/custom/navbar/NotificationTray.tsx
+++ b/src/components/custom/navbar/NotificationTray.tsx
@@ -1,0 +1,214 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { useEffect, useState, useCallback } from 'react'
+import { Bell } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
+import { getConfiguration } from '@/lib/fineract-openapi'
+import { NotificationApi } from '@/fineract-api'
+
+interface Notification {
+  id?: number
+  objectType?: string
+  objectId?: number
+  action?: string
+  content?: string
+  isRead?: boolean
+  createdAt?: string | number[]
+}
+
+const NotificationTray = () => {
+  const [unreadNotifications, setUnreadNotifications] = useState<Notification[]>([])
+  const [readNotifications, setReadNotifications] = useState<Notification[]>([])
+  const [displayedReadNotifications, setDisplayedReadNotifications] = useState<Notification[]>([])
+  const [isOpen, setIsOpen] = useState(false)
+
+  // Format date from array or string
+  const formatDate = (createdAt?: string | number[]): string => {
+    if (!createdAt) return 'N/A'
+    
+    try {
+      if (Array.isArray(createdAt)) {
+        // Handle array format [year, month, day, hour, minute, second]
+        const [year, month, day, hour, minute] = createdAt
+        const date = new Date(year, month - 1, day, hour || 0, minute || 0)
+        return new Intl.DateTimeFormat('en-GB', {
+          day: '2-digit',
+          month: 'short',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        }).format(date)
+      } else {
+        // Handle string format
+        return new Intl.DateTimeFormat('en-GB', {
+          day: '2-digit',
+          month: 'short',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        }).format(new Date(createdAt))
+      }
+    } catch {
+      return 'N/A'
+    }
+  }
+
+  // Fetch notifications
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const api = new NotificationApi(getConfiguration())
+      const [unreadResponse, readResponse] = await Promise.all([
+        api.getAllNotifications(undefined, 9, undefined, undefined, false),
+        api.getAllNotifications(undefined, 9, undefined, undefined, true),
+      ])
+
+      const unread = unreadResponse.data.pageItems || []
+      const read = readResponse.data.pageItems || []
+
+      setUnreadNotifications(unread)
+      setReadNotifications(read)
+
+      // Display read notifications to fill up to 9 items total
+      const displayCount = Math.max(0, 9 - unread.length)
+      setDisplayedReadNotifications(read.slice(0, displayCount))
+    } catch (error) {
+      console.error('Failed to fetch notifications:', error)
+    }
+  }, [])
+
+  // Initial fetch
+  useEffect(() => {
+    fetchNotifications()
+  }, [fetchNotifications])
+
+  // Poll for new notifications every 60 seconds
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchNotifications()
+    }, 60000) // 60 seconds
+
+    return () => clearInterval(interval)
+  }, [fetchNotifications])
+
+  // Mark notifications as read when menu closes
+  const handleOpenChange = async (open: boolean) => {
+    setIsOpen(open)
+
+    if (!open && unreadNotifications.length > 0) {
+      try {
+        const api = new NotificationApi(getConfiguration())
+        // Mark all as read on the server
+        await api.update5()
+
+        // Update local state: move unread to read
+        const newlyRead = unreadNotifications
+        setReadNotifications((prev) => {
+          const nextRead = [...newlyRead, ...prev]
+          const displayCount = 9
+          // Update displayed read notifications based on the next read state
+          setDisplayedReadNotifications(nextRead.slice(0, displayCount))
+          return nextRead
+        })
+        setUnreadNotifications([])
+      } catch (error) {
+        console.error('Failed to mark notifications as read:', error)
+      }
+    }
+  }
+
+  // Navigate to notification entity
+  const handleNotificationClick = (notification: Notification) => {
+    // TODO: Implement navigation when modules are complete
+    // For now, do nothing when notification is clicked
+  }
+
+  const allNotifications = [...unreadNotifications, ...displayedReadNotifications]
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className="relative hover:text-gray-200 transition-colors hover:bg-transparent dark:hover:bg-transparent cursor-pointer"
+        >
+          <Bell className="w-5 h-5" />
+          {unreadNotifications.length > 0 && (
+            <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-[10px] font-semibold text-white">
+              {unreadNotifications.length}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align="end"
+        className="w-80 max-h-[500px] overflow-y-auto"
+        sideOffset={8}
+      >
+        {allNotifications.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
+            <Bell className="w-16 h-16 text-gray-300 dark:text-gray-600 mb-3" />
+            <p className="text-sm text-gray-500 dark:text-gray-400 font-medium">
+              No notifications
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                Notifications
+              </h3>
+            </div>
+
+            {allNotifications.map((notification, index) => {
+              const isUnread = index < unreadNotifications.length
+
+              return (
+                <DropdownMenuItem
+                  key={notification.id || index}
+                  className={`flex flex-col items-start px-4 py-3 cursor-pointer border-b border-gray-100 dark:border-gray-800 ${
+                    isUnread
+                      ? 'bg-blue-50 dark:bg-blue-950/20'
+                      : 'bg-white dark:bg-transparent'
+                  }`}
+                  onClick={() => handleNotificationClick(notification)}
+                >
+                  <div className="flex items-start justify-between w-full gap-2 mb-1">
+                    <span
+                      className={`text-sm flex-1 ${
+                        isUnread
+                          ? 'font-medium text-gray-900 dark:text-gray-100'
+                          : 'font-normal text-gray-600 dark:text-gray-400'
+                      }`}
+                    >
+                      {notification.content || 'No content'}
+                    </span>
+                    {isUnread && (
+                      <span className="text-blue-500 text-lg leading-none mt-1">•</span>
+                    )}
+                  </div>
+                  <span className="text-xs text-gray-500 dark:text-gray-500">
+                    {formatDate(notification.createdAt)}
+                  </span>
+                </DropdownMenuItem>
+              )
+            })}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export default NotificationTray

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -42,6 +42,14 @@ export const getAllHeaders = (): Record<string, string> => {
 }
 
 export const getApiBaseUrl = (): string => {
+  // Check localStorage for the server URL first (set during login)
+  const mifosServer = localStorage.getItem('mifosServer')
+  if (mifosServer) {
+    const server = mifosServer.trim().replace(/\/+$/, '')
+    return `${server}/fineract-provider/api`
+  }
+
+  // Fall back to environment config
   const url = envConfig.apiUrl;
   const provider = envConfig.apiProvider;
   const version = envConfig.apiVersion;

--- a/src/lib/notificationsApi.ts
+++ b/src/lib/notificationsApi.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * @deprecated This module previously contained a custom axios-based
+ * notifications API wrapper.
+ *
+ * The application now uses the generated OpenAPI `NotificationApi`
+ * from '@/fineract-api' instead. This file is intentionally left
+ * as a placeholder to avoid having a parallel, unused implementation
+ * that could diverge from the canonical API client.
+ *
+ * If you need to interact with notifications, use:
+ * ```typescript
+ * import { NotificationApi } from '@/fineract-api'
+ * import { getConfiguration } from '@/lib/fineract-openapi'
+ *
+ * const api = new NotificationApi(getConfiguration())
+ * ```
+ */
+
+// Intentionally empty - use NotificationApi from @/fineract-api instead
+export {}


### PR DESCRIPTION
## Description

Created a fully functional NotificationTray component that fetches notifications from the logged-in Fineract server using the OpenAPI client. Integrated it into the navbar with bell icon, badge counter, auto-refresh every 60 seconds, and mark-as-read functionality. Updated http-client to prioritize mifosServer from localStorage over environment config.
## Related issues and discussion

#{Issue Number}

## Screenshots, if any

before


https://github.com/user-attachments/assets/b5943553-1af8-4c74-a6d0-e01421317f4b


after

https://github.com/user-attachments/assets/80390cfe-c8e4-4ac5-99f9-6a55190b4eef



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added notification tray to the navigation bar displaying unread and read notifications
  * Notification badge shows count of unread messages
  * Dropdown menu automatically refreshes notifications every 60 seconds
  * Notifications are automatically marked as read when the menu closes
  * Support for custom server URL configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->