### PR TITLE
MXWAR-74 fix(login): make axios proxy-aware and avoid localServer overide

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -11,6 +11,7 @@ import {
   getAuthHeaders,
   getDefaultHeaders,
 } from '@/lib/http-client'
+import { envConfig } from '@/lib/env-config'
 
 const getBaseURL = () => {
   const rawServer =
@@ -39,8 +40,15 @@ fineract.interceptors.request.use(config => {
 
   Object.assign(config.headers, authHeaders)
 
-  // Update baseURL dynamically in case it changed
-  config.baseURL = getBaseURL()
+  // Only override baseURL from localStorage when NOT running behind the
+  // Docker/nginx reverse-proxy.  In Docker, envConfig.apiUrl is empty and
+  // the axios instance was already created with a correct relative baseURL
+  // (e.g. "/fineract-provider/api/") that routes through the same-origin
+  // nginx proxy — overriding it with the localStorage value would break
+  // that by sending the request directly to https://localhost:8443.
+  if (envConfig.apiUrl) {
+    config.baseURL = getBaseURL()
+  }
 
   return config
 })

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -38,6 +38,7 @@ import {
 import { useNavigate } from 'react-router-dom'
 import { useTranslation, Trans } from 'react-i18next'
 import { LanguageSwitcher } from '@/components/custom/language-switcher/LanguageSwitcher'
+import { envConfig } from '@/lib/env-config'
 
 const Login = () => {
   const navigate = useNavigate()
@@ -54,7 +55,9 @@ const Login = () => {
   const { loading, error } = useSelector((state: RootState) => state.auth)
 
   const [form, setForm] = useState({ username: '', password: '' })
+  const isDockerProxy = !envConfig.apiUrl
   const [server, setServer] = useState(() => {
+    if (isDockerProxy) return ''
     return localStorage.getItem('mifosServer') || 'https://localhost:8443'
   })
   const [tenant, setTenant] = useState(() => {
@@ -68,7 +71,9 @@ const Login = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    localStorage.setItem('mifosServer', server)
+    if (!isDockerProxy) {
+      localStorage.setItem('mifosServer', server)
+    }
     localStorage.setItem('mifosTenant', tenant)
     dispatch(loginUser(form))
   }
@@ -134,30 +139,32 @@ const Login = () => {
 
       <div className="flex flex-col w-full min-h-screen lg:w-[30%] bg-white dark:bg-zinc-900 px-4 py-6 sm:px-10 justify-between">
         <div className="lg:h-[10%] flex flex-wrap gap-2 text-center justify-center">
-          <Select value={server} onValueChange={handleServerChange}>
-            <SelectTrigger className="w-[160px]">
-              <Label className=" text-zinc-900 dark:text-white">
-                {t('auth:login.server')}
-              </Label>
-              <SelectValue placeholder="https://localhost:8443" />
-            </SelectTrigger>
-            <SelectContent className="dark:bg-zinc-800 dark:text-white">
-              <SelectGroup>
-                <SelectItem value="https://sandbox.mifos.community">
-                  https://sandbox.mifos.community
-                </SelectItem>
-                <SelectItem value="https://demo.mifos.community">
-                  https://demo.mifos.community
-                </SelectItem>
-                <SelectItem value="https://localhost:8443">
-                  https://localhost:8443
-                </SelectItem>
-                <SelectItem value="http://localhost:4200">
-                  http://localhost:4200
-                </SelectItem>
-              </SelectGroup>
-            </SelectContent>
-          </Select>
+          {!isDockerProxy && (
+            <Select value={server} onValueChange={handleServerChange}>
+              <SelectTrigger className="w-[160px]">
+                <Label className=" text-zinc-900 dark:text-white">
+                  {t('auth:login.server')}
+                </Label>
+                <SelectValue placeholder="https://localhost:8443" />
+              </SelectTrigger>
+              <SelectContent className="dark:bg-zinc-800 dark:text-white">
+                <SelectGroup>
+                  <SelectItem value="https://sandbox.mifos.community">
+                    https://sandbox.mifos.community
+                  </SelectItem>
+                  <SelectItem value="https://demo.mifos.community">
+                    https://demo.mifos.community
+                  </SelectItem>
+                  <SelectItem value="https://localhost:8443">
+                    https://localhost:8443
+                  </SelectItem>
+                  <SelectItem value="http://localhost:4200">
+                    http://localhost:4200
+                  </SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          )}
 
           <LanguageSwitcher className="w-[140px] dark:bg-zinc-800 dark:text-white" />
 


### PR DESCRIPTION
This pr Fixes login failures when running the stack in Docker by ensuring the frontend routes API calls through the nginx proxy and by providing DB credentials for a clean Fineract initialization.

[MXWAR-74](https://mifosforge.jira.com/browse/MXWAR-74)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-74]: https://mifosforge.jira.com/browse/MXWAR-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved support for Docker and nginx reverse proxy deployments by intelligently managing server configuration handling
  * Fixed potential issues with same-origin requests in reverse proxy environments
  * Server selection UI now dynamically hides when not applicable based on deployment type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->