### PR TITLE
fix(openapfix(openapi): add isSelfServiceUser to GetUsersResponse and GetUsersUserIdResponsei): add isSelfServiceUser to GetUsersResponse and GetUsersU…

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -44663,6 +44663,9 @@ components:
         username:
           type: string
           example: mifos
+        isSelfServiceUser:
+          type: boolean
+          example: false
     GetUsersTemplateResponse:
       type: object
       description: GetUsersTemplateResponse
@@ -44719,6 +44722,9 @@ components:
         username:
           type: string
           example: mifos
+        isSelfServiceUser:
+          type: boolean
+          example: false
     GetWorkingDaysTemplateResponse:
       type: object
       description: GetWorkingDaysTemplateResponse


### PR DESCRIPTION
## Summary
Added missing `isSelfServiceUser` boolean field to:
- `GetUsersResponse` (used in `/users` endpoint)
- `GetUsersUserIdResponse` (used in `/users/{id}` endpoint)

## Problem
The `isSelfServiceUser` field was missing from the OpenAPI spec, 
causing the generated TypeScript client to not include this field,
which is returned by the Fineract backend.

## Changes
- Added `isSelfServiceUser: boolean` to `GetUsersResponse` schema
- Added `isSelfServiceUser: boolean` to `GetUsersUserIdResponse` schema
- Regenerated Fineract API client

## Related
Fixes item listed in ISSUES.md under Admin Users section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a self-service user indicator to user information displays. This new field appears in user lists, user details, and template responses, providing consistent identification of self-service accounts across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->