### PR TITLE
fix(openapi): add parentId and parentName to GetOfficesResponse

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -38290,6 +38290,13 @@ components:
         openingDate:
           type: string
           format: date
+        parentId:
+          type: integer
+          format: int64
+          example: 1
+        parentName:
+          type: string
+          example: Head Office
     GetOfficesTemplateResponse:
       type: object
       description: GetOfficesTemplateResponse


### PR DESCRIPTION
## Summary
Added missing fields to `GetOfficesResponse` schema:
- `parentId` (integer) 
- `parentName` (string)

## Problem
These fields were missing from the OpenAPI spec, causing the 
Organization → Offices page to not display parent office information.

## Changes
- Added `parentId` and `parentName` to `GetOfficesResponse` schema

## Related
Fixes item listed in ISSUES.md under Admin Organization section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced office hierarchy support with parent office tracking
  * Expanded account data models for loans, savings, and shares with more detailed financial tracking
  * Added comprehensive interest calculation and recalculation properties
  * Introduced detailed transaction and fee management structures
  * Improved scheduling and calendar management capabilities
  * Extended account linking and relationship tracking for better data organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->