### PR TITLE
fix(openapi): add disabled field to GetRolesResponse

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -40432,6 +40432,9 @@ components:
         name:
           type: string
           example: Super Users
+        disabled:
+          type: boolean
+          example: false
     GetRolesRoleIdPermissionsResponse:
       type: object
       description: GetRolesRoleIdPermissionsResponse


### PR DESCRIPTION
## Summary
Added missing `disabled` boolean field to `GetRolesResponse` schema.

## Problem
The `disabled` field was missing from the OpenAPI spec, causing 
the System → Roles & Permissions page to not display role status correctly.

## Changes
- Added `disabled: boolean` to `GetRolesResponse` schema

## Related
Fixes item listed in ISSUES.md under Admin System section
