### PR TITLE
fix(openapi): add entitySubType to GetDataTablesResponse

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -32221,6 +32221,9 @@ components:
         registeredTableName:
           type: string
           example: extra_client_details
+        entitySubType:
+          type: string
+          example: PERSON
     GetDelinquencyActionsResponse:
       type: object
       description: GetDelinquencyActionsResponse


### PR DESCRIPTION
## Summary
Added missing `entitySubType` string field to `GetDataTablesResponse` schema.

## Problem
The `entitySubType` field was missing from the OpenAPI spec, 
causing TypeScript errors on the System → Data Tables page.

## Changes
- Added `entitySubType: string` to `GetDataTablesResponse` schema

## Related
Fixes item listed in ISSUES.md under Admin System section
