### PR TITLE
fix(openapi): add accountNo and externalId to GetCentersPageItems

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -30875,6 +30875,12 @@ components:
           example: Head Office
         status:
           $ref: '#/components/schemas/GetCentersStatus'
+        accountNo:
+          type: string
+          example: '000-1234'
+        externalId:
+          type: string
+          example: EXT-001
     GetCentersResponse:
       type: object
       description: GetCentersResponse


### PR DESCRIPTION
## Summary
Added missing fields to `GetCentersPageItems` schema:
- `accountNo` (string)
- `externalId` (string)

## Problem
These fields were missing from the OpenAPI spec, causing 
the Institution Centers page to not display account number 
and external ID correctly.

## Changes
- Added `accountNo` and `externalId` to `GetCentersPageItems` schema

## Related
Fixes item listed in ISSUES.md under Institution Centers section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional account number and external ID identifier fields to center API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->