### PR TITLE
fix(openapi): add accountNo, externalId and activationDate to GetCentersCenterIdResponse

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -30784,6 +30784,15 @@ components:
           example: Head Office
         status:
           $ref: '#/components/schemas/GetCentersStatus'
+        accountNo:
+          type: string
+          example: '000-1234'
+        externalId:
+          type: string
+          example: EXT-001
+        activationDate:
+          type: string
+          format: date
     GetCentersCenterIdStatus:
       type: object
       properties:


### PR DESCRIPTION
## Summary
Added missing fields to `GetCentersCenterIdResponse` schema:
- `accountNo` (string)
- `externalId` (string)
- `activationDate` (date)

## Problem
These fields were missing from the OpenAPI spec, causing 
TypeScript errors on the Institution Centers detail page.

## Changes
- Added `accountNo`, `externalId` and `activationDate` 
  to `GetCentersCenterIdResponse` schema

## Related
Fixes item listed in ISSUES.md under Institution Centers section