### PR TITLE
fix(openapi): add staffId, externalId, submittedOnDate and activationDate to PostGroupsResponse

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -50518,6 +50518,19 @@ components:
           type: integer
           format: int64
           example: 2
+        staffId:
+          type: integer
+          format: int64
+          example: 1
+        externalId:
+          type: string
+          example: EXT-001
+        submittedOnDate:
+          type: string
+          format: date
+        activationDate:
+          type: string
+          format: date
     PostHolidaysHolidayIdRequest:
       type: object
       description: PostHolidaysHolidayIdRequest


### PR DESCRIPTION
## Summary
Added missing fields to `PostGroupsResponse` schema:
- `staffId` (integer)
- `externalId` (string)
- `submittedOnDate` (date)
- `activationDate` (date)

## Problem
These fields were missing from the OpenAPI spec, 
preventing group creation from working correctly.

## Changes
- Added 4 missing fields to `PostGroupsResponse` schema

## Related
Fixes item listed in ISSUES.md under Institution Groups section
