### PR TITLE
fix(openapi): add clientTransactiondates to GetClientsChargesPageItems

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -31483,6 +31483,11 @@ components:
         penalty:
           type: boolean
           example: true
+        clientTransactiondates:
+          type: array
+          items:
+            type: string
+            format: date
     GetClientsClientIdAccountsResponse:
       type: object
       description: GetClientsClientIdAccountsResponse


### PR DESCRIPTION
## Summary
Added missing `clientTransactiondates` array field to 
`GetClientsChargesPageItems` schema.

## Problem
The `clientTransactiondates` field was missing from the OpenAPI spec,
causing issues on the Institution Clients charges page.

## Changes
- Added `clientTransactiondates` array of dates to 
  `GetClientsChargesPageItems` schema

## Related
Fixes item listed in ISSUES.md under Institution Clients section
