### PR TITLE
fix(users): display isSelfServiceUser field in ViewUsers page

### DIFF
--- a/src/pages/users/ViewUsers.tsx
+++ b/src/pages/users/ViewUsers.tsx
@@ -172,7 +172,7 @@ const ViewUsers = () => {
 
           <div className="font-medium">Is Self Service</div>
           <div className="text-zinc-600 dark:text-zinc-400">
-            {'Missing in OpenApi'}
+            {users?.isSelfServiceUser ? 'Yes' : 'No'}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Fixed the ViewUsers page to display the actual `isSelfServiceUser` 
value instead of the hardcoded 'Missing in OpenApi' text.

## Problem
The `isSelfServiceUser` field was hardcoded as 'Missing in OpenApi' 
in the ViewUsers page because the field was missing from the 
OpenAPI spec.

## Changes
- Updated `ViewUsers.tsx` to display `isSelfServiceUser` as 'Yes' or 'No'

## Screenshots
Before: Shows 'Missing in OpenApi'
After: Shows 'Yes' or 'No' based on actual value

## Related
- Depends on fix(openapi): add isSelfServiceUser to GetUsersResponse (#88)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced placeholder text with a dynamic display of self-service user status, showing "Yes" or "No" instead of a static placeholder, improving clarity and accuracy in the user view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->