### PR TITLE
fix(ui): display missing OpenAPI fields in ManageDataTables, RolesAndPermissions and Users pages

### DIFF
--- a/src/pages/system/manage-data-tables/ManageDataTables.tsx
+++ b/src/pages/system/manage-data-tables/ManageDataTables.tsx
@@ -170,7 +170,7 @@ const ManageDataTables = () => {
                   {table.applicationTableName || '—'}
                 </TableCell>
                 <TableCell className="px-6 py-4 text-zinc-700 dark:text-zinc-200">
-                  {'Missing in OpenAPI'}
+                  {(table as any).entitySubType ?? '—'}
                 </TableCell>
               </TableRow>
             ))}

--- a/src/pages/system/roles-and-permissions/RolesAndPermissions.tsx
+++ b/src/pages/system/roles-and-permissions/RolesAndPermissions.tsx
@@ -175,7 +175,7 @@ const RolesAndPermissions = () => {
                   {role.description || '—'}
                 </TableCell>
                 <TableCell className="px-6 py-4">
-                  {'missing in OpenApi'}
+                  {(role as any).disabled ? 'Disabled' : 'Enabled'}
                 </TableCell>
                 <TableCell className="px-6 py-4">
                   {role.description && (

--- a/src/pages/system/roles-and-permissions/RolesAndPermissions.tsx
+++ b/src/pages/system/roles-and-permissions/RolesAndPermissions.tsx
@@ -175,7 +175,11 @@ const RolesAndPermissions = () => {
                   {role.description || '—'}
                 </TableCell>
                 <TableCell className="px-6 py-4">
-                  {(role as any).disabled ? 'Disabled' : 'Enabled'}
+                  {(role as any).disabled === true
+                    ? 'Disabled'
+                    : (role as any).disabled === false
+                      ? 'Enabled'
+                      : 'Unknown'}
                 </TableCell>
                 <TableCell className="px-6 py-4">
                   {role.description && (

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -193,7 +193,7 @@ const Users = () => {
                   {user.officeName}
                 </TableCell>
                 <TableCell className="px-6 py-4 text-zinc-700 dark:text-zinc-200">
-                  {'Missing in OpenApi'}
+                  {(user as any).isSelfServiceUser ? 'Yes' : 'No'}
                 </TableCell>
               </TableRow>
             ))}

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -193,7 +193,11 @@ const Users = () => {
                   {user.officeName}
                 </TableCell>
                 <TableCell className="px-6 py-4 text-zinc-700 dark:text-zinc-200">
-                  {(user as any).isSelfServiceUser ? 'Yes' : 'No'}
+                  {(user as any).isSelfServiceUser === true
+                    ? 'Yes'
+                    : (user as any).isSelfServiceUser === false
+                      ? 'No'
+                      : '—'}
                 </TableCell>
               </TableRow>
             ))}


### PR DESCRIPTION
## Summary
Fixed 3 pages that were showing hardcoded 'Missing in OpenApi' 
text by replacing them with actual field values.

## Problem
Several pages had placeholder text instead of real data because 
fields were missing from the OpenAPI spec.

## Changes
- `ManageDataTables.tsx` → display `entitySubType` field
- `RolesAndPermissions.tsx` → display `disabled` status as 'Enabled'/'Disabled'
- `Users.tsx` → display `isSelfServiceUser` as 'Yes'/'No'

## Related
- Depends on fix(openapi): add entitySubType to GetDataTablesResponse (#91)
- Depends on fix(openapi): add disabled field to GetRolesResponse (#90)
- Depends on fix(openapi): add isSelfServiceUser to GetUsersResponse (#88)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed placeholder text appearing in system management tables.
  * "Sub Type" column now shows actual entity sub-type or a clear fallback.
  * Role "Status" column now shows Disabled/Enabled/Unknown appropriately.
  * User "Is Self Service" column now displays Yes/No or a clear fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->