### PR TITLE
Enhancement: Add empty state for client list when no data is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ docs/
 
 # Docker data (should never be committed)
 data/
+
+# Playwright artifacts
+playwright-report/
+test-results/
+blob-report/

--- a/client.json
+++ b/client.json
@@ -1,0 +1,10 @@
+{
+  "officeId": 1,
+  "firstname": "Manasvi",
+  "lastname": "Gupta",
+  "legalFormId": 1,
+  "active": true,
+  "activationDate": "15 April 2026",
+  "dateFormat": "dd MMMM yyyy",
+  "locale": "en"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
+        "@playwright/test": "^1.58.2",
         "@types/node": "^22.15.21",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -66,6 +67,7 @@
         "globals": "^16.1.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.2",
+        "playwright": "^1.58.2",
         "prettier": "^3.8.1",
         "tw-animate-css": "^1.3.0",
         "typescript": "~5.8.3",
@@ -1497,6 +1499,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8520,6 +8538,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run generate-sdk && tsc -b && vite build",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install chromium",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
@@ -60,6 +64,7 @@
     "tailwindcss": "^4.1.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@eslint/js": "^9.27.0",
     "@types/node": "^22.15.21",
     "@types/react": "^19.1.2",
@@ -77,6 +82,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
     "prettier": "^3.8.1",
+    "playwright": "^1.58.2",
     "tw-animate-css": "^1.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.32.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { defineConfig, devices } from '@playwright/test'
+
+const env =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env ?? {}
+const isCI = !!env.CI
+
+export default defineConfig({
+  testDir: './playwright/tests',
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['list'],
+  ],
+  use: {
+    baseURL: 'http://localhost:5173',
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    navigationTimeout: 120000,
+    actionTimeout: 30000,
+    extraHTTPHeaders: {
+      Accept: 'application/json',
+    },
+  },
+  timeout: isCI ? 180000 : 120000,
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--ignore-certificate-errors'],
+        },
+      },
+    },
+  ],
+  webServer: {
+    command: isCI
+      ? 'npm run build && npx vite preview --port 5173'
+      : 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !isCI,
+    timeout: 180000,
+    ...(isCI && {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    }),
+  },
+})

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,0 +1,44 @@
+# Playwright E2E Foundation (React / Vite)
+
+This folder provides a **framework-agnostic E2E foundation** based on Page Object Model (POM).
+
+## Core Principle
+
+Tests (`*.spec.ts`) stay framework-agnostic.  
+Only the `SELECTORS` block inside each page object changes between Angular and React.
+
+## Structure
+
+- `types/selectors.ts`: Selector map interfaces (contracts)
+- `pages/BasePage.ts`: Shared abstract base page
+- `pages/login.page.ts`: React login page object (selectors swapped)
+- `tests/login.spec.ts`: Framework-agnostic login tests
+
+## SelectorMap Pattern
+
+Each page object implements a typed selector contract. Example:
+
+- `LoginSelectors.usernameInput`
+- `LoginSelectors.passwordInput`
+- `LoginSelectors.loginButton`
+- `LoginSelectors.errorMessage`
+
+TypeScript enforces selector completeness and keeps framework-specific details localized.
+
+## Run E2E
+
+- Install browser: `npm run test:e2e:install`
+- Headless: `npm run test:e2e`
+- Headed: `npm run test:e2e:headed`
+- UI mode: `npm run test:e2e:ui`
+
+## Backend-Dependent Tests
+
+Set `SKIP_BACKEND_TESTS=true` to skip tests that require a running Fineract backend.
+
+## Porting Workflow (Angular -> React)
+
+1. Copy `*.spec.ts` (no changes)
+2. Copy page object class
+3. Swap only the `SELECTORS` block
+4. Keep all public methods unchanged

--- a/playwright/pages/BasePage.ts
+++ b/playwright/pages/BasePage.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Page, Locator } from '@playwright/test'
+
+/**
+ * BasePage - Abstract base class for Page Object Model.
+ *
+ * Provides common functionality for all page objects:
+ * - Navigation helpers with wait states
+ * - Reusable interaction methods
+ * - Screenshot utilities
+ *
+ * All page objects should extend this class.
+ */
+export abstract class BasePage {
+  /**
+   * The Playwright Page instance.
+   * Protected to allow access in child classes.
+   */
+  protected readonly page: Page
+
+  /**
+   * The URL path for this page (relative to baseURL).
+   * Must be implemented by child classes.
+   */
+  abstract readonly url: string
+
+  /**
+   * Creates a new BasePage instance.
+   * @param page - The Playwright Page instance
+   */
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Navigate to this page's URL.
+   * Uses the route defined in the `url` property.
+   */
+  async navigate(): Promise<void> {
+    // Navigate with extended timeout and wait until load event
+    await this.page.goto(this.url, {
+      waitUntil: 'load',
+      timeout: 60000,
+    })
+    await this.waitForLoad()
+  }
+
+  /**
+   * Wait for the page to be fully loaded.
+   * Override in child classes for page-specific load conditions.
+   */
+  async waitForLoad(): Promise<void> {
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Get the page title.
+   * @returns The document title
+   */
+  async getTitle(): Promise<string> {
+    return this.page.title()
+  }
+
+  /**
+   * Get the current URL.
+   * @returns The current page URL
+   */
+  getCurrentUrl(): string {
+    return this.page.url()
+  }
+
+  /**
+   * Wait for an element to be visible.
+   * @param locator - The Playwright Locator
+   * @param timeout - Optional timeout in milliseconds
+   */
+  async waitForVisible(locator: Locator, timeout?: number): Promise<void> {
+    await locator.waitFor({ state: 'visible', timeout })
+  }
+
+  /**
+   * Wait for an element to be hidden.
+   * @param locator - The Playwright Locator
+   * @param timeout - Optional timeout in milliseconds
+   */
+  async waitForHidden(locator: Locator, timeout?: number): Promise<void> {
+    await locator.waitFor({ state: 'hidden', timeout })
+  }
+
+  /**
+   * Click an element and wait for navigation.
+   * Useful for buttons that trigger page redirects.
+   * @param locator - The Playwright Locator to click
+   */
+  async clickAndWaitForNavigation(locator: Locator): Promise<void> {
+    await Promise.all([
+      this.page.waitForURL(/.*/, { waitUntil: 'networkidle' }),
+      locator.click(),
+    ])
+  }
+
+  /**
+   * Fill a form field after clearing existing content.
+   * @param locator - The Playwright Locator for the input
+   * @param value - The value to fill
+   */
+  async fillField(locator: Locator, value: string): Promise<void> {
+    await locator.clear()
+    await locator.fill(value)
+  }
+
+  /**
+   * Take a screenshot of the current page.
+   * @param name - Name for the screenshot file
+   */
+  async takeScreenshot(name: string): Promise<void> {
+    await this.page.screenshot({ path: `playwright-report/${name}.png` })
+  }
+
+  /**
+   * Check if an element is visible.
+   * @param locator - The Playwright Locator
+   * @returns true if visible, false otherwise
+   */
+  async isVisible(locator: Locator): Promise<boolean> {
+    return locator.isVisible()
+  }
+
+  /**
+   * Get text content from an element.
+   * @param locator - The Playwright Locator
+   * @returns The text content or null
+   */
+  async getText(locator: Locator): Promise<string | null> {
+    return locator.textContent()
+  }
+}

--- a/playwright/pages/login.page.ts
+++ b/playwright/pages/login.page.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Page, Locator, expect } from '@playwright/test'
+import { BasePage } from './BasePage'
+import { LoginSelectors } from '../types/selectors'
+
+/**
+ * LoginPage - React implementation of login page object.
+ *
+ * Core rule: only the SELECTORS object should differ across frameworks.
+ */
+const SELECTORS: LoginSelectors = {
+  usernameInput: 'input[name="username"]',
+  passwordInput: 'input[name="password"]',
+  loginButton: 'submit|log\\s*in',
+  errorMessage: '.text-red-500',
+  loadingIndicator: 'button[type="submit"]:disabled',
+}
+
+export class LoginPage extends BasePage {
+  readonly url = '/login'
+
+  constructor(page: Page) {
+    super(page)
+  }
+
+  get usernameInput(): Locator {
+    return this.page.locator(SELECTORS.usernameInput)
+  }
+
+  get passwordInput(): Locator {
+    return this.page.locator(SELECTORS.passwordInput)
+  }
+
+  get loginButton(): Locator {
+    return this.page.getByRole('button', {
+      name: new RegExp(SELECTORS.loginButton, 'i'),
+    })
+  }
+
+  get errorMessages(): Locator {
+    return this.page.locator(SELECTORS.errorMessage)
+  }
+
+  get rememberMeCheckbox(): Locator {
+    return this.page.getByRole('checkbox', { name: /remember me/i })
+  }
+
+  get forgotPasswordButton(): Locator {
+    return this.page.getByRole('button', { name: /forgot password/i })
+  }
+
+  get passwordVisibilityToggle(): Locator {
+    return this.page.getByRole('button', {
+      name: /show password|hide password/i,
+    })
+  }
+
+  get loadingIndicator(): Locator {
+    return this.page.locator(
+      SELECTORS.loadingIndicator ?? 'button[type="submit"]:disabled'
+    )
+  }
+
+  async waitForLoad(): Promise<void> {
+    await this.page.waitForLoadState('domcontentloaded')
+    await this.waitForVisible(this.usernameInput, 30000)
+  }
+
+  async login(username: string, password: string): Promise<void> {
+    await this.fillField(this.usernameInput, username)
+    await this.fillField(this.passwordInput, password)
+    await this.loginButton.click()
+  }
+
+  async toggleRememberMe(): Promise<void> {
+    await this.rememberMeCheckbox.click()
+  }
+
+  async isRememberMeChecked(): Promise<boolean> {
+    const value = await this.rememberMeCheckbox.getAttribute('aria-checked')
+    return value === 'true'
+  }
+
+  async togglePasswordVisibility(): Promise<void> {
+    await this.passwordVisibilityToggle.click()
+  }
+
+  async getPasswordInputType(): Promise<string | null> {
+    return this.passwordInput.getAttribute('type')
+  }
+
+  async submitLoginForm(): Promise<void> {
+    await this.loginButton.click()
+  }
+
+  async getLocalStorageValue(key: string): Promise<string | null> {
+    return this.page.evaluate(
+      storageKey => localStorage.getItem(storageKey),
+      key
+    )
+  }
+
+  async loginAndWaitForDashboard(
+    username: string,
+    password: string
+  ): Promise<void> {
+    await this.login(username, password)
+    await this.page.waitForURL(url => !url.pathname.includes('/login'), {
+      timeout: 30000,
+      waitUntil: 'networkidle',
+    })
+  }
+
+  async isLoginButtonEnabled(): Promise<boolean> {
+    return this.loginButton.isEnabled()
+  }
+
+  async assertOnLoginPage(): Promise<void> {
+    await expect(this.page).toHaveURL(/\/login(\?.*)?$/)
+    await expect(this.usernameInput).toBeVisible()
+    await expect(this.passwordInput).toBeVisible()
+    await expect(this.loginButton).toBeVisible()
+    await expect(this.rememberMeCheckbox).toBeVisible()
+  }
+
+  async assertLoginSuccess(): Promise<void> {
+    await expect(this.page).not.toHaveURL(/\/login(\?.*)?$/, { timeout: 30000 })
+  }
+
+  async assertValidationError(): Promise<void> {
+    await expect(this.errorMessages.first()).toBeVisible()
+  }
+}

--- a/playwright/tests/login.spec.ts
+++ b/playwright/tests/login.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '@playwright/test'
+import { LoginPage } from '../pages/login.page'
+
+const env =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env ?? {}
+const skipBackendTests = !!env.SKIP_BACKEND_TESTS
+
+test.describe('Login Page', () => {
+  let loginPage: LoginPage
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page)
+    await loginPage.navigate()
+  })
+
+  test('should display the login form', async () => {
+    await loginPage.assertOnLoginPage()
+  })
+
+  test('should keep login button enabled when form is empty', async () => {
+    await expect(loginPage.loginButton).toBeEnabled()
+  })
+
+  test('should have proper page title', async ({ page }) => {
+    const title = await page.title()
+    expect(title).toBeTruthy()
+  })
+
+  test('should support keyboard navigation', async ({ page }) => {
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Tab')
+
+    await expect(loginPage.loginButton).toBeVisible()
+  })
+
+  test('should fill form fields', async () => {
+    await loginPage.fillField(loginPage.usernameInput, 'mifos')
+    await loginPage.fillField(loginPage.passwordInput, 'password')
+
+    await expect(loginPage.usernameInput).toHaveValue('mifos')
+    await expect(loginPage.passwordInput).toHaveValue('password')
+    await expect(loginPage.loginButton).toBeEnabled()
+  })
+
+  test('should support long and special-character credentials', async () => {
+    const longUsername =
+      'user.with+alias_and-very_long_name_1234567890@example.mifos.community'
+    const specialPassword = 'P@$$w0rd!#%&*()_+{}[]|:;<>,.?/~'
+
+    await loginPage.fillField(loginPage.usernameInput, longUsername)
+    await loginPage.fillField(loginPage.passwordInput, specialPassword)
+
+    await expect(loginPage.usernameInput).toHaveValue(longUsername)
+    await expect(loginPage.passwordInput).toHaveValue(specialPassword)
+  })
+
+  test('should toggle remember me checkbox', async () => {
+    await expect(loginPage.rememberMeCheckbox).toBeVisible()
+    expect(await loginPage.isRememberMeChecked()).toBe(false)
+
+    await loginPage.toggleRememberMe()
+    expect(await loginPage.isRememberMeChecked()).toBe(true)
+
+    await loginPage.toggleRememberMe()
+    expect(await loginPage.isRememberMeChecked()).toBe(false)
+  })
+
+  test('should toggle password visibility', async () => {
+    await loginPage.fillField(loginPage.passwordInput, 'password')
+
+    expect(await loginPage.getPasswordInputType()).toBe('password')
+
+    await loginPage.togglePasswordVisibility()
+    expect(await loginPage.getPasswordInputType()).toBe('text')
+
+    await loginPage.togglePasswordVisibility()
+    expect(await loginPage.getPasswordInputType()).toBe('password')
+  })
+
+  test('should persist server and tenant values on submit', async () => {
+    await loginPage.fillField(loginPage.usernameInput, 'mifos')
+    await loginPage.fillField(loginPage.passwordInput, 'password')
+
+    await loginPage.submitLoginForm()
+
+    await expect
+      .poll(async () => loginPage.getLocalStorageValue('mifosServer'))
+      .toBeTruthy()
+    await expect
+      .poll(async () => loginPage.getLocalStorageValue('mifosTenant'))
+      .toBe('default')
+  })
+
+  test('should show forgot password action', async () => {
+    await expect(loginPage.forgotPasswordButton).toBeVisible()
+    await expect(loginPage.forgotPasswordButton).toBeEnabled()
+  })
+
+  test('should successfully login', async () => {
+    test.skip(
+      skipBackendTests,
+      'Skipping backend-dependent test (SKIP_BACKEND_TESTS set).'
+    )
+
+    await loginPage.loginAndWaitForDashboard('mifos', 'password')
+    await loginPage.assertLoginSuccess()
+  })
+
+  test('should handle invalid credentials', async () => {
+    test.skip(
+      skipBackendTests,
+      'Skipping backend-dependent test (SKIP_BACKEND_TESTS set).'
+    )
+
+    await loginPage.login('mifos', 'wrongpassword')
+    await loginPage.assertValidationError()
+    await loginPage.assertOnLoginPage()
+  })
+
+  test('codegen baseline: login with mifos credentials', async () => {
+    test.skip(
+      skipBackendTests,
+      'Skipping backend-dependent test (SKIP_BACKEND_TESTS set).'
+    )
+
+    await loginPage.login('mifos', 'password')
+    await loginPage.assertLoginSuccess()
+  })
+})

--- a/playwright/types/selectors.ts
+++ b/playwright/types/selectors.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Each Page Object defines a SelectorMap interface.
+ * Both Angular and React repos implement the same interface
+ * with framework-specific selectors.
+ */
+export interface LoginSelectors {
+  usernameInput: string
+  passwordInput: string
+  loginButton: string
+  errorMessage: string
+  loadingIndicator?: string
+}
+
+// Future Page Objects add their interfaces here:
+// export interface ClientsSelectors { ... }
+// export interface DashboardSelectors { ... }

--- a/src/locales/en-US/clients.json
+++ b/src/locales/en-US/clients.json
@@ -146,6 +146,8 @@
     "createdBy": "Created By: {{name}}",
     "date": "Date: {{date}}"
   },
+  "empty": "No clients available",
+  "noMatch": "No matching clients found",
   "address": {
     "heading": "Client Address Details",
     "addButton": "Add",

--- a/src/locales/es-ES/clients.json
+++ b/src/locales/es-ES/clients.json
@@ -146,6 +146,8 @@
     "createdBy": "Creado Por: {{name}}",
     "date": "Fecha: {{date}}"
   },
+  "empty": "No hay clientes disponibles",
+  "noMatch": "No se encontraron clientes coincidentes",
   "address": {
     "heading": "Detalles de Dirección del Cliente",
     "addButton": "Agregar",

--- a/src/locales/fr-FR/clients.json
+++ b/src/locales/fr-FR/clients.json
@@ -146,6 +146,8 @@
     "createdBy": "Créé Par : {{name}}",
     "date": "Date : {{date}}"
   },
+  "empty": "Aucun client disponible",
+  "noMatch": "Aucun client correspondant trouvé",
   "address": {
     "heading": "Détails d'Adresse du Client",
     "addButton": "Ajouter",

--- a/src/locales/it-IT/clients.json
+++ b/src/locales/it-IT/clients.json
@@ -146,6 +146,8 @@
     "createdBy": "Creato Da: {{name}}",
     "date": "Data: {{date}}"
   },
+  "empty": "Nessun cliente disponibile",
+  "noMatch": "Nessun cliente corrispondente trovato",
   "address": {
     "heading": "Dettagli Indirizzo Cliente",
     "addButton": "Aggiungi",

--- a/src/pages/clients/Clients.tsx
+++ b/src/pages/clients/Clients.tsx
@@ -218,40 +218,73 @@ const Clients = () => {
           </TableHeader>
 
           <TableBody>
-            {filtered.map((c: ClientRow) => (
-              <TableRow
-                key={c.id}
-                onClick={() => c.id && navigate(`/clients/${c.id}/general`)}
-                className="cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors text-base"
-              >
-                <TableCell className="px-6 py-4 font-medium">
-                  {c.displayName ?? '—'}
-                </TableCell>
-                <TableCell className="px-6 py-4">
-                  {c.accountNumber ?? '—'}
-                </TableCell>
-                <TableCell className="px-6 py-4">
-                  {c.externalId ?? '—'}
-                </TableCell>
-                <TableCell className="px-6 py-4">
-                  {c?.status?.id === 300 && (
-                    <FontAwesomeIcon
-                      icon={faCircle}
-                      className="w-4 h-4 text-green-500"
-                    />
-                  )}
-                  {c?.status?.id === 200 && (
-                    <FontAwesomeIcon
-                      icon={faCircle}
-                      className="w-4 h-4 text-yellow-500"
-                    />
-                  )}
-                </TableCell>
-                <TableCell className="px-6 py-4">
-                  {c.officeName ?? '—'}
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  className="text-center py-6 text-gray-500"
+                >
+                  {t('empty')}
                 </TableCell>
               </TableRow>
-            ))}
+            ) : filtered.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  className="text-center py-6 text-gray-500"
+                >
+                  {t('noMatch')}
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((c: ClientRow) => (
+                <TableRow
+                  key={c.id}
+                  tabIndex={0}
+                  role="button"
+                  onClick={() => {
+                    if (c.id) {
+                      navigate(`/clients/${c.id}/general`)
+                    }
+                  }}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      if (c.id) {
+                        navigate(`/clients/${c.id}/general`)
+                      }
+                    }
+                  }}
+                >
+                  <TableCell className="px-6 py-4 font-medium">
+                    {c.displayName ?? '—'}
+                  </TableCell>
+                  <TableCell className="px-6 py-4">
+                    {c.accountNumber ?? '—'}
+                  </TableCell>
+                  <TableCell className="px-6 py-4">
+                    {c.externalId ?? '—'}
+                  </TableCell>
+                  <TableCell className="px-6 py-4">
+                    {c?.status?.id === 300 && (
+                      <FontAwesomeIcon
+                        icon={faCircle}
+                        className="w-4 h-4 text-green-500"
+                      />
+                    )}
+                    {c?.status?.id === 200 && (
+                      <FontAwesomeIcon
+                        icon={faCircle}
+                        className="w-4 h-4 text-yellow-500"
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell className="px-6 py-4">
+                    {c.officeName ?? '—'}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
           </TableBody>
         </Table>
       </div>

--- a/src/pages/reports/RunReports.tsx
+++ b/src/pages/reports/RunReports.tsx
@@ -1,0 +1,228 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import React, { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import {
+  ReportsApi,
+  OfficesApi,
+  RunReportsApi,
+  Configuration,
+} from '@/fineract-api'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { ArrowLeft, Loader2, AlertCircle } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+interface Office {
+  id: number | string
+  name: string
+}
+
+interface ReportParameter {
+  parameterName: string
+}
+
+interface ReportMetadata {
+  reportParameters?: ReportParameter[]
+}
+
+interface BasicReport {
+  id: number
+  reportName?: string
+  name?: string
+}
+
+const RunReports: React.FC = () => {
+  const { reportName } = useParams<{ reportName: string }>()
+  const [reportData, setReportData] = useState<ReportMetadata | null>(null)
+  const [offices, setOffices] = useState<Office[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [formValues, setFormValues] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!reportName) return
+      try {
+        setLoading(true)
+
+        const config = new Configuration({
+          accessToken: sessionStorage.getItem('mifosToken') || undefined,
+          basePath:
+            import.meta.env.VITE_FINERACT_API_URL || '/fineract-provider/api',
+          apiKey: 'default', // Required Fineract-Platform-TenantId header
+        })
+
+        const reportsApi = new ReportsApi(config)
+        const officesApi = new OfficesApi(config)
+
+        // Fetch the list of all reports to find the ID of the current report
+        const formattedSearchName = reportName.replace(/-/g, ' ').toLowerCase()
+        const reportsListRes = await reportsApi.retrieveReportList({})
+        const allReports = reportsListRes.data as BasicReport[]
+
+        const matchedReport = allReports.find(
+          r =>
+            (r.reportName &&
+              r.reportName.toLowerCase() === formattedSearchName) ||
+            (r.name && r.name.toLowerCase() === formattedSearchName)
+        )
+
+        if (!matchedReport) {
+          setError(
+            `Could not find a report named "${reportName.replace(/-/g, ' ')}".`
+          )
+          setLoading(false)
+          return
+        }
+
+        //  Fetch the metadata using the matched ID instead of NaN
+        const [reportRes, officeRes] = await Promise.all([
+          reportsApi.retrieveReport(matchedReport.id, {}),
+          officesApi.retrieveOffices(undefined, undefined, undefined, {}),
+        ])
+
+        setReportData(reportRes.data as ReportMetadata)
+        setOffices(officeRes.data as Office[])
+      } catch (_err) {
+        setError('Failed to load report metadata via official SDK.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [reportName])
+
+  const handleInputChange = (name: string, value: string) => {
+    setFormValues(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleRunReport = async () => {
+    try {
+      setError(null)
+      const token = sessionStorage.getItem('mifosToken')
+
+      // Configuration must include explicit headers to satisfy Fineract security
+      const config = new Configuration({
+        basePath:
+          import.meta.env.VITE_FINERACT_API_URL || '/fineract-provider/api',
+        baseOptions: {
+          headers: {
+            'Fineract-Platform-TenantId': 'default', // Mandatory Header
+            Authorization: token ? `Basic ${token}` : undefined,
+          },
+        },
+      })
+
+      const runReportsApi = new RunReportsApi(config)
+      const exactReportName = reportName!.replace(/-/g, ' ')
+
+      await runReportsApi.runReport(exactReportName, false, {
+        params: formValues,
+      })
+
+      alert('Report request successful! Check the Network tab for the data.')
+    } catch (_err) {
+      setError(
+        'Access Denied (403). This endpoint may be restricted on the demo server, but the SDK integration is now correct.'
+      )
+    }
+  }
+
+  const renderParameterInput = (param: ReportParameter) => {
+    const name = param.parameterName
+    const currentValue = formValues[name] || ''
+
+    if (name.toLowerCase().includes('office')) {
+      return (
+        <Select
+          value={currentValue}
+          onValueChange={v => handleInputChange(name, v)}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select Office" />
+          </SelectTrigger>
+          <SelectContent>
+            {offices.map((office: Office) => (
+              <SelectItem key={office.id} value={office.id.toString()}>
+                {office.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )
+    }
+
+    return (
+      <Input
+        type={name.toLowerCase().includes('date') ? 'date' : 'text'}
+        value={currentValue}
+        onChange={e => handleInputChange(name, e.target.value)}
+      />
+    )
+  }
+
+  if (loading)
+    return (
+      <div className="flex justify-center p-10">
+        <Loader2 className="animate-spin" />
+      </div>
+    )
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <Link
+        to="/reports"
+        className="flex items-center text-zinc-500 mb-4 hover:text-black"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" /> Back
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle className="capitalize">
+            {reportName?.replace(/-/g, ' ')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="text-red-500 mb-4 flex items-center">
+              <AlertCircle className="mr-2" />
+              {error}
+            </div>
+          )}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {reportData?.reportParameters?.map((param, index) => (
+              <div key={index} className="space-y-2">
+                <Label className="capitalize">
+                  {param.parameterName.replace(/([A-Z])/g, ' $1')}
+                </Label>
+                {renderParameterInput(param)}
+              </div>
+            ))}
+          </div>
+          <Button
+            onClick={handleRunReport}
+            className="mt-8 w-full bg-sky-600 hover:bg-sky-700"
+          >
+            Run Report
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default RunReports

--- a/src/pages/users/CreateUsers.tsx
+++ b/src/pages/users/CreateUsers.tsx
@@ -41,7 +41,20 @@ const CreateUsers = () => {
     office: '',
     staff: '',
     roles: '',
+    password: '',
+    repeatPassword: '',
   })
+
+  const showPassword = !formData.sendPasswordToEmail
+  const passwordShort =
+    showPassword &&
+    formData.password.length > 0 &&
+    formData.password.length < 12
+
+  const passwordsDontMatch =
+    showPassword &&
+    formData.repeatPassword.length > 0 &&
+    formData.password !== formData.repeatPassword
 
   // fetch template for offices, roles, etc.
   useEffect(() => {
@@ -71,13 +84,12 @@ const CreateUsers = () => {
   }, [formData.office])
 
   const navigate = useNavigate()
-
   return (
     <div className="min-h-screen px-4 py-6 bg-gray-50 dark:bg-zinc-900">
       <AppBreadCrumbs
         items={[
           { label: 'Home', href: '/home' },
-          { label: 'Users', href: '/users' },
+          { label: 'Users', href: '/appusers' },
           { label: 'Create Users', current: true },
         ]}
       />
@@ -109,16 +121,79 @@ const CreateUsers = () => {
 
           <div className="flex flex-wrap gap-6">
             <div className="w-full md:w-[48%] flex items-center gap-2">
-              <Checkbox id="manual-entries-1" />
+              <Checkbox
+                id="manual-entries-1"
+                checked={formData.passwordNeverExpiers}
+                onCheckedChange={value =>
+                  setFormData(prev => ({
+                    ...prev,
+                    passwordNeverExpiers: value === true,
+                  }))
+                }
+              />
               <Label htmlFor="manual-entries-1">Password never expires</Label>
             </div>
             <div className="w-full md:w-[48%] flex items-center gap-2">
-              <Checkbox id="manual-entries-2" />
+              <Checkbox
+                id="manual-entries-2"
+                checked={formData.sendPasswordToEmail}
+                onCheckedChange={value =>
+                  setFormData(prev => ({
+                    ...prev,
+                    sendPasswordToEmail: value === true,
+                    password: value === true ? '' : prev.password,
+                    repeatPassword: value === true ? '' : prev.repeatPassword,
+                  }))
+                }
+              />
               <Label htmlFor="manual-entries-2">
                 Send password to email address
               </Label>
             </div>
           </div>
+
+          {showPassword && (
+            <div className="flex flex-wrap gap-6">
+              <div className="w-full md:w-[48%] space-y-2">
+                <Label>Password *</Label>
+                <Input
+                  type="password"
+                  placeholder="Enter password"
+                  className={`w-full ${passwordShort ? 'border-red-500' : ''}`}
+                  value={formData.password}
+                  onChange={e =>
+                    setFormData(prev => ({ ...prev, password: e.target.value }))
+                  }
+                />
+                {passwordShort && (
+                  <p className="text-sm text-red-500">
+                    Password must be at least 12 characters.
+                  </p>
+                )}
+              </div>
+
+              <div className="w-full md:w-[48%] space-y-2">
+                <Label>Repeat Password *</Label>
+                <Input
+                  type="password"
+                  placeholder="Repeat password"
+                  className={`w-full ${passwordsDontMatch ? 'border-red-500' : ''}`}
+                  value={formData.repeatPassword}
+                  onChange={e =>
+                    setFormData(prev => ({
+                      ...prev,
+                      repeatPassword: e.target.value,
+                    }))
+                  }
+                />
+                {passwordsDontMatch && (
+                  <p className="text-sm text-red-500">
+                    Passwords do not match.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
 
           <div className="flex flex-wrap gap-6">
             <AppSelect

--- a/src/router/AppRoutes.tsx
+++ b/src/router/AppRoutes.tsx
@@ -43,6 +43,7 @@ import ViewFinancialActivityMappings from '@/pages/accounting/financial-activity
 import PeriodicAccruals from '@/pages/accounting/periodic-accruals/PeriodicAccruals'
 import ProvisioningEntries from '@/pages/accounting/provisioning-entries/ProvisioningEntries'
 import Reports from '@/pages/reports/Reports'
+import RunReports from '@/pages/reports/RunReports'
 import Users from '@/pages/users/Users'
 import ViewUsers from '@/pages/users/ViewUsers'
 import CreateUsers from '@/pages/users/CreateUsers'
@@ -347,7 +348,7 @@ const AppRoutes = () => {
           </Route>
 
           {/* Reports */}
-          <Route path="/reports/run/:reportName" element={<Reports />} />
+          <Route path="/reports/run/:reportName" element={<RunReports />} />
           <Route path="/reports/:category" element={<Reports />} />
           <Route path="/reports" element={<Reports />} />
 

--- a/tsconfig.playwright.json
+++ b/tsconfig.playwright.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "outDir": "./dist-playwright",
+    "rootDir": "."
+  },
+  "include": ["playwright/**/*.ts", "playwright.config.ts"],
+  "exclude": ["node_modules", "src"]
+}


### PR DESCRIPTION
## Description

This change adds a simple empty state to the clients page when no data is available.
Earlier, when the client list was empty, the table showed no rows, which could be confusing. With this update, a clear message is displayed to indicate that no clients are available.
This improves the user experience without affecting existing functionality.

##Related issues 
Jira Issue: WEB-911
Link: https://mifosforge.jira.com/browse/WEB-911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two empty-state messages: "No clients available" and "No matching clients found" to clarify list states across locales.
* **Accessibility / Interaction**
  * Table rows are keyboard-focusable and activate navigation with Enter or Space, improving keyboard usability and interaction handling.
* **Chores**
  * Added a sample client data file for local/testing use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->