### PR TITLE
Multiple Errors on Create Users Page

### DIFF
--- a/src/pages/users/CreateUsers.tsx
+++ b/src/pages/users/CreateUsers.tsx
@@ -41,7 +41,20 @@ const CreateUsers = () => {
     office: '',
     staff: '',
     roles: '',
+    password: '',
+    repeatPassword: '',
   })
+
+  const showPassword = !formData.sendPasswordToEmail
+  const passwordShort =
+    showPassword &&
+    formData.password.length > 0 &&
+    formData.password.length < 12
+
+  const passwordsDontMatch =
+    showPassword &&
+    formData.repeatPassword.length > 0 &&
+    formData.password !== formData.repeatPassword
 
   // fetch template for offices, roles, etc.
   useEffect(() => {
@@ -71,13 +84,12 @@ const CreateUsers = () => {
   }, [formData.office])
 
   const navigate = useNavigate()
-
   return (
     <div className="min-h-screen px-4 py-6 bg-gray-50 dark:bg-zinc-900">
       <AppBreadCrumbs
         items={[
           { label: 'Home', href: '/home' },
-          { label: 'Users', href: '/users' },
+          { label: 'Users', href: '/appusers' },
           { label: 'Create Users', current: true },
         ]}
       />
@@ -109,16 +121,79 @@ const CreateUsers = () => {
 
           <div className="flex flex-wrap gap-6">
             <div className="w-full md:w-[48%] flex items-center gap-2">
-              <Checkbox id="manual-entries-1" />
+              <Checkbox
+                id="manual-entries-1"
+                checked={formData.passwordNeverExpiers}
+                onCheckedChange={value =>
+                  setFormData(prev => ({
+                    ...prev,
+                    passwordNeverExpiers: value === true,
+                  }))
+                }
+              />
               <Label htmlFor="manual-entries-1">Password never expires</Label>
             </div>
             <div className="w-full md:w-[48%] flex items-center gap-2">
-              <Checkbox id="manual-entries-2" />
+              <Checkbox
+                id="manual-entries-2"
+                checked={formData.sendPasswordToEmail}
+                onCheckedChange={value =>
+                  setFormData(prev => ({
+                    ...prev,
+                    sendPasswordToEmail: value === true,
+                    password: value === true ? '' : prev.password,
+                    repeatPassword: value === true ? '' : prev.repeatPassword,
+                  }))
+                }
+              />
               <Label htmlFor="manual-entries-2">
                 Send password to email address
               </Label>
             </div>
           </div>
+
+          {showPassword && (
+            <div className="flex flex-wrap gap-6">
+              <div className="w-full md:w-[48%] space-y-2">
+                <Label>Password *</Label>
+                <Input
+                  type="password"
+                  placeholder="Enter password"
+                  className={`w-full ${passwordShort ? 'border-red-500' : ''}`}
+                  value={formData.password}
+                  onChange={e =>
+                    setFormData(prev => ({ ...prev, password: e.target.value }))
+                  }
+                />
+                {passwordShort && (
+                  <p className="text-sm text-red-500">
+                    Password must be at least 12 characters.
+                  </p>
+                )}
+              </div>
+
+              <div className="w-full md:w-[48%] space-y-2">
+                <Label>Repeat Password *</Label>
+                <Input
+                  type="password"
+                  placeholder="Repeat password"
+                  className={`w-full ${passwordsDontMatch ? 'border-red-500' : ''}`}
+                  value={formData.repeatPassword}
+                  onChange={e =>
+                    setFormData(prev => ({
+                      ...prev,
+                      repeatPassword: e.target.value,
+                    }))
+                  }
+                />
+                {passwordsDontMatch && (
+                  <p className="text-sm text-red-500">
+                    Passwords do not match.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
 
           <div className="flex flex-wrap gap-6">
             <AppSelect


### PR DESCRIPTION
JIRA TICKET: [MXWAR-77](https://mifosforge.jira.com/browse/MXWAR-77)
## Description

Multiple Errors on Create Users Page
1. Password flag is unchecked (it should be checked by default)
2. Leaving password unchecked, should give entering password and confirm password options, but it doesn’t
3. Navigation bug in breadcrumb

## Screenshots, if any
**Original Web App:**
<img width="1524" height="787" alt="image" src="https://github.com/user-attachments/assets/49a730bb-68a9-4686-a93a-27c51cda63b8" />

**React Web App Before:**
<img width="1612" height="842" alt="image" src="https://github.com/user-attachments/assets/120ee5bb-64a9-43c2-aa25-03f7f4b9cd28" />

**React Web App After:**
<img width="1396" height="753" alt="image" src="https://github.com/user-attachments/assets/f8038e04-495e-4f24-8382-16135573f660" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-77]: https://mifosforge.jira.com/browse/MXWAR-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced user creation form: optional manual password entry with confirmation and inline validation messages

* **Changes**
  * Option to enter a password manually or have it sent via email; choosing email clears manual password fields
  * Visual validation feedback for password errors and controlled "Password never expires" checkbox
  * Breadcrumbs and Cancel navigation updated to the new Users path (/appusers)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->