### PR TITLE
MXWAR-79: Fix clients repair broken action button navigation on client general tab

### DIFF
--- a/src/pages/clients/clients-view/general-tab/ClientsGeneralTab.tsx
+++ b/src/pages/clients/clients-view/general-tab/ClientsGeneralTab.tsx
@@ -426,7 +426,7 @@ const ClientsGeneralTab = () => {
                       className="bg-[#1074b9] hover:bg-[#0662a3]"
                       onClick={() =>
                         navigate(
-                          `/clients/${id}/loans-accounts/${acc.id}/actions/Make Repayment`
+                          `/clients/${id}/loans-accounts/${acc.id}/actions/MakeRepayment`
                         )
                       }
                     >
@@ -606,7 +606,7 @@ const ClientsGeneralTab = () => {
                           className="bg-[#1074b9] hover:bg-[#0662a3]"
                           onClick={() =>
                             navigate(
-                              `/clients/${id}/savings-accounts/${acc.id}/actions/Undo Approval`
+                              `/clients/${id}/savings-accounts/${acc.id}/actions/UndoApproval`
                             )
                           }
                         >
@@ -726,7 +726,7 @@ const ClientsGeneralTab = () => {
                           className="bg-[#1074b9] hover:bg-[#0662a3]"
                           onClick={() =>
                             navigate(
-                              `/clients/${id}/shares-accounts/${acc.id}/actions/Undo Approval`
+                              `/clients/${id}/shares-accounts/${acc.id}/actions/UndoApproval`
                             )
                           }
                         >

--- a/src/router/AppRoutes.tsx
+++ b/src/router/AppRoutes.tsx
@@ -842,6 +842,14 @@ const AppRoutes = () => {
             path="/clients/:groupId/savings-accounts/:accountId/actions/Deposit"
             element={<SavingsAccountTransactions />}
           />
+          <Route
+            path="/clients/:groupId/savings-accounts/:accountId/actions/Withdrawal"
+            element={<SavingsAccountTransactions />}
+          />
+          <Route
+            path="/clients/:groupId/savings-accounts/:accountId/actions/UndoApproval"
+            element={<UndoApprovalSavingsAccount />}
+          />
 
           <Route
             path="/clients/:clientId/shares-accounts/:sharesAccountId"
@@ -1128,6 +1136,14 @@ const AppRoutes = () => {
           <Route
             path="/clients/:groupId/savings-accounts/:accountId/actions/Deposit"
             element={<SavingsAccountTransactions />}
+          />
+          <Route
+            path="/clients/:groupId/savings-accounts/:accountId/actions/Withdrawal"
+            element={<SavingsAccountTransactions />}
+          />
+          <Route
+            path="/clients/:groupId/savings-accounts/:accountId/actions/UndoApproval"
+            element={<UndoApprovalSavingsAccount />}
           />
 
           {/* Loans */}


### PR DESCRIPTION
## Description

Action buttons on the Client general tab were navigating to URLs that matched no defined route, causing a 404 on every click. Three `navigate()` calls contained spaces in the action segment (`Make Repayment`, `Undo Approval`) while the actual routes use camelCase (`MakeRepayment`, `UndoApproval`). Additionally, the Withdrawal and UndoApproval actions for client savings accounts had no corresponding routes defined at all, despite the equivalent group savings routes existing correctly.

Changes:
- Corrected `Make Repayment` to `MakeRepayment` in the loans action navigate call
- Corrected `Undo Approval` to `UndoApproval` in both savings and shares action navigate calls
- Added missing `Withdrawal` and `UndoApproval` routes for `/clients/` savings accounts in both client savings route blocks in `AppRoutes.tsx`


## Screenshots

#### Before:

<img width="1919" height="963" alt="Screenshot 2026-04-24 190300" src="https://github.com/user-attachments/assets/38430c96-e147-4264-bf81-1feec3abe5e2" />


#### After:

<img width="1869" height="967" alt="image" src="https://github.com/user-attachments/assets/e800018c-ee3a-40ba-b354-a1cf1f8ba2c1" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


JIRA issue at: https://mifosforge.jira.com/browse/MXWAR-79

