### PR TITLE
MXWAR-81: Fix pending clients filter and pagination reset

### DIFF
--- a/src/pages/clients/Clients.tsx
+++ b/src/pages/clients/Clients.tsx
@@ -32,11 +32,11 @@ import { Plus } from 'lucide-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircle } from '@fortawesome/free-solid-svg-icons'
 
-import { ClientSearchV2Api, type PageClientSearchData } from '@/fineract-api'
+import { ClientApi } from '@/fineract-api'
 import { getConfiguration } from '@/lib/fineract-openapi'
 import { useTranslation } from 'react-i18next'
 
-const clientSearchApi = new ClientSearchV2Api(getConfiguration())
+const clientApi = new ClientApi(getConfiguration())
 
 /** Row shape returned by the search endpoint at runtime */
 interface ClientRow {
@@ -69,15 +69,21 @@ const Clients = () => {
 
     ;(async () => {
       try {
-        const res = await clientSearchApi.searchByText({
-          request: { text: searchTerm || undefined },
-          page: Math.max(0, page - 1),
-          size: itemsPerPage,
-        })
-
-        const data: PageClientSearchData = res.data || {}
-        const content = (data.content ?? []) as unknown as ClientRow[]
-        const totalElements: number = data.totalElements ?? content.length
+        const res = await clientApi.retrieveAll21(
+          undefined,
+          undefined,
+          searchTerm || undefined,
+          undefined,
+          undefined,
+          includePending ? undefined : 'active',
+          undefined,
+          Math.max(0, page - 1) * itemsPerPage,
+          itemsPerPage
+        )
+        const data = res.data as any
+        const content = (data.pageItems ?? []) as unknown as ClientRow[]
+        const totalElements: number =
+          data.totalFilteredRecords ?? content.length
 
         if (!cancelled) {
           setRows(content)
@@ -95,15 +101,7 @@ const Clients = () => {
     return () => {
       cancelled = true
     }
-  }, [searchTerm, page, itemsPerPage])
-
-  // toggle pending/active filter
-  const filtered = rows.filter((c: ClientRow) => {
-    const statusId = c?.status?.id ?? 0
-    return includePending
-      ? statusId === 300 || statusId === 100
-      : statusId === 300
-  })
+  }, [searchTerm, page, itemsPerPage, includePending])
 
   const totalPages = Math.max(1, Math.ceil(total / itemsPerPage))
 
@@ -182,7 +180,10 @@ const Clients = () => {
         <Checkbox
           id="pending-clients"
           checked={includePending}
-          onCheckedChange={v => setIncludePending(!!v)}
+          onCheckedChange={v => {
+            setIncludePending(!!v)
+            setPage(1)
+          }}
         />
         <label htmlFor="pending-clients" className="text-base dark:text-white">
           {t('pending.showPendingClients')}
@@ -194,7 +195,7 @@ const Clients = () => {
         <Table>
           <TableCaption className="text-sm text-gray-500 dark:text-gray-400 pt-6 pb-2">
             {tc('pagination.showing', {
-              current: filtered.length,
+              current: rows.length,
               total,
               page,
               pages: totalPages,
@@ -218,7 +219,7 @@ const Clients = () => {
           </TableHeader>
 
           <TableBody>
-            {filtered.map((c: ClientRow) => (
+            {rows.map((c: ClientRow) => (
               <TableRow
                 key={c.id}
                 onClick={() => c.id && navigate(`/clients/${c.id}/general`)}


### PR DESCRIPTION
## Description

The "Show Pending Clients" checkbox was silently broken: it filtered only the rows already fetched for the current page rather than querying the server, so toggling it on page 2 or beyond would show zero results even when pending clients existed. The pagination counter was also wrong because it still reflected the unfiltered server total.

The fix moves the status filter to the server by switching to `ClientApi.retrieveAll21`, which accepts a `status` query parameter. When the checkbox is off the API receives `status: 'active'`; when it's on the parameter is omitted and the server returns all statuses. The client-side `rows.filter()` block is removed since it is no longer needed, and the page is reset to 1 whenever the filter, search term, or page size changes so the counter always stays accurate.

## Related issues and discussion

#MXWAR-81

## Screenshots, if any

Before: bugged, only 17 out of 22 entries visible `show pending` ineffective

https://github.com/user-attachments/assets/4f06cc1f-08f5-46a5-b908-cfd8e597a0a9

/////////////////

After: fixed pagination correctly reflects number of clients (22)

https://github.com/user-attachments/assets/8913474d-d3e3-4f76-a9b1-ceaadd6777ab



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client search and filtering behavior to ensure accurate results and proper pagination
  * Fixed active/pending status filter to correctly update results when toggled
  
* **Refactor**
  * Optimized client data retrieval and filtering performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->