### PR TITLE
MXWAR-82: fix(groups): staffId, externalId and dates silently dropped in create and edit group API calls

### DIFF
--- a/src/pages/groups/CreateGroups.tsx
+++ b/src/pages/groups/CreateGroups.tsx
@@ -23,6 +23,8 @@ import {
   type StaffData,
 } from '@/fineract-api'
 import { getConfiguration } from '@/lib/fineract-openapi'
+import { inputToFineractDate } from '@/lib/date-utils'
+import type { ExtendedPostGroupsRequest } from '@/pages/groups/types'
 import { useTranslation } from 'react-i18next'
 
 const groupsApi = new GroupsApi(getConfiguration())
@@ -79,15 +81,17 @@ const CreateGroups = () => {
       await groupsApi.create8({
         name: formData.name,
         officeId: Number(formData.officeId),
-        // staffId: formData.staffId,
         active: formData.active,
-        // externalId: formData.externalId || undefined,
-        // submittedOnDate: formData.submittedOnDate || undefined,
-        // activationDate:
-        //   formData.active && formData.activationDate
-        //     ? formData.activationDate
-        //     : undefined,
-      })
+        staffId: formData.staffId ? Number(formData.staffId) : undefined,
+        externalId: formData.externalId || undefined,
+        submittedOnDate: inputToFineractDate(formData.submittedOnDate),
+        activationDate:
+          formData.active && formData.activationDate
+            ? inputToFineractDate(formData.activationDate)
+            : undefined,
+        dateFormat: 'dd MMMM yyyy',
+        locale: 'en',
+      } as ExtendedPostGroupsRequest)
       navigate('/groups')
     } catch (e) {
       console.error('Failed to create group', e)

--- a/src/pages/groups/CreateGroups.tsx
+++ b/src/pages/groups/CreateGroups.tsx
@@ -83,7 +83,7 @@ const CreateGroups = () => {
         officeId: Number(formData.officeId),
         active: formData.active,
         staffId: formData.staffId ? Number(formData.staffId) : undefined,
-        externalId: formData.externalId || undefined,
+        externalId: formData.externalId.trim() || undefined,
         submittedOnDate: inputToFineractDate(formData.submittedOnDate),
         activationDate:
           formData.active && formData.activationDate

--- a/src/pages/groups/groups-view/group-actions/EditGroups.tsx
+++ b/src/pages/groups/groups-view/group-actions/EditGroups.tsx
@@ -15,7 +15,10 @@ import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 
 import { GroupsApi } from '@/fineract-api'
-import type { ExtendedGroupResponse } from '@/pages/groups/types'
+import type {
+  ExtendedGroupResponse,
+  ExtendedPutGroupsRequest,
+} from '@/pages/groups/types'
 import { getConfiguration } from '@/lib/fineract-openapi'
 import { dateArrayToInputValue, inputToFineractDate } from '@/lib/date-utils'
 import { useTranslation } from 'react-i18next'
@@ -91,7 +94,7 @@ const EditGroups = () => {
       if (act) payload.activationDate = act
       if (externalId.trim()) payload.externalId = externalId.trim()
 
-      await groupsApi.update13(Number(id), { name: payload.name as string })
+      await groupsApi.update13(Number(id), payload as ExtendedPutGroupsRequest)
       navigate(`/groups/${id}/general`)
     } catch (err) {
       console.error('Failed to update group', err)

--- a/src/pages/groups/groups-view/group-actions/EditGroups.tsx
+++ b/src/pages/groups/groups-view/group-actions/EditGroups.tsx
@@ -63,7 +63,7 @@ const EditGroups = () => {
             groupData?.timeline?.activatedOnDate as number[] | null
           )
         )
-        // externalId left blank on purpose, user must fill if needed
+        setExternalId(groupData.externalId ?? '')
       } catch (err) {
         console.error("Can't fetch group", err)
       }
@@ -81,7 +81,7 @@ const EditGroups = () => {
     if (!id) return
     setSaving(true)
     try {
-      const payload: Record<string, unknown> = {
+      const payload: ExtendedPutGroupsRequest = {
         name: name.trim(),
         locale: 'en',
         dateFormat: 'dd MMMM yyyy',
@@ -92,9 +92,9 @@ const EditGroups = () => {
       if (sub) payload.submittedOnDate = sub
       const act = inputToFineractDate(activationOn)
       if (act) payload.activationDate = act
-      if (externalId.trim()) payload.externalId = externalId.trim()
+      payload.externalId = externalId.trim() || undefined
 
-      await groupsApi.update13(Number(id), payload as ExtendedPutGroupsRequest)
+      await groupsApi.update13(Number(id), payload)
       navigate(`/groups/${id}/general`)
     } catch (err) {
       console.error('Failed to update group', err)

--- a/src/pages/groups/types.ts
+++ b/src/pages/groups/types.ts
@@ -57,11 +57,11 @@ export interface ClientMember {
 }
 
 /**
- * The generated PostGroupsRequest is missing fields that the real Fineract
- * API accepts. This interface extends it with the undeclared fields so that
- * CreateGroups.tsx can pass a complete payload without TypeScript errors.
+ * Fields missing from both PostGroupsRequest and PutGroupsGroupIdRequest in
+ * the generated OpenAPI types. Extracted here so both extended interfaces stay
+ * in sync if more fields are discovered later.
  */
-export interface ExtendedPostGroupsRequest extends PostGroupsRequest {
+interface GroupRequestExtras {
   staffId?: number
   externalId?: string
   submittedOnDate?: string
@@ -70,16 +70,8 @@ export interface ExtendedPostGroupsRequest extends PostGroupsRequest {
   locale?: string
 }
 
-/**
- * The generated PutGroupsGroupIdRequest only declares name. This interface
- * extends it with the remaining fields the API accepts so that EditGroups.tsx
- * can pass the full payload it already constructs.
- */
-export interface ExtendedPutGroupsRequest extends PutGroupsGroupIdRequest {
-  staffId?: number
-  externalId?: string
-  submittedOnDate?: string
-  activationDate?: string
-  dateFormat?: string
-  locale?: string
-}
+export interface ExtendedPostGroupsRequest
+  extends PostGroupsRequest, GroupRequestExtras {}
+
+export interface ExtendedPutGroupsRequest
+  extends PutGroupsGroupIdRequest, GroupRequestExtras {}

--- a/src/pages/groups/types.ts
+++ b/src/pages/groups/types.ts
@@ -5,7 +5,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import type { GetGroupsGroupIdResponse } from '@/fineract-api'
+import type {
+  GetGroupsGroupIdResponse,
+  PostGroupsRequest,
+  PutGroupsGroupIdRequest,
+} from '@/fineract-api'
 
 /**
  * The generated `GetGroupsGroupIdResponse` is incomplete — the real API
@@ -50,4 +54,32 @@ export interface ClientMember {
   id?: number
   displayName?: string
   officeName?: string
+}
+
+/**
+ * The generated PostGroupsRequest is missing fields that the real Fineract
+ * API accepts. This interface extends it with the undeclared fields so that
+ * CreateGroups.tsx can pass a complete payload without TypeScript errors.
+ */
+export interface ExtendedPostGroupsRequest extends PostGroupsRequest {
+  staffId?: number
+  externalId?: string
+  submittedOnDate?: string
+  activationDate?: string
+  dateFormat?: string
+  locale?: string
+}
+
+/**
+ * The generated PutGroupsGroupIdRequest only declares name. This interface
+ * extends it with the remaining fields the API accepts so that EditGroups.tsx
+ * can pass the full payload it already constructs.
+ */
+export interface ExtendedPutGroupsRequest extends PutGroupsGroupIdRequest {
+  staffId?: number
+  externalId?: string
+  submittedOnDate?: string
+  activationDate?: string
+  dateFormat?: string
+  locale?: string
 }


### PR DESCRIPTION
## Description

The generated `PostGroupsRequest` and `PutGroupsGroupIdRequest` types from `fineract.yaml` are missing several fields the Fineract API actually accepts. This caused two silent data-loss bugs:

- **CreateGroups.tsx** => `staffId`, `externalId`, `submittedOnDate`, and `activationDate` were commented out to satisfy TypeScript and never sent to the API.
- **EditGroups.tsx** => the full payload was built correctly but only `{ name }` was passed to `groupsApi.update13()`, discarding everything else.

Fix: extended the generated types locally in `types.ts` with `ExtendedPostGroupsRequest` and `ExtendedPutGroupsRequest`, and updated both components to pass the complete payload.

## Related issues and discussion

[[MXWAR-82](https://mifosforge.jira.com/browse/MXWAR-82)](https://mifosforge.jira.com/browse/MXWAR-82)

## Screenshots, if any

**Before: Edit Group PUT payload:**
<img width="1615" height="905" alt="Screenshot 2026-04-25 101819" src="https://github.com/user-attachments/assets/405d29e2-4472-4d17-a4ce-ec32c1d18cf2" />

```json
{ "name": "Bug Test grp" }
```


**After: Edit Group PUT payload:**
<img width="1766" height="951" alt="Screenshot 2026-04-25 102813" src="https://github.com/user-attachments/assets/f17c75fe-7b97-44f7-9724-fc38c6af3124" />

```json
{
  "name": "Bug Test grp", "staffId": 1, "externalId": "EXT-111",
  "submittedOnDate": "08 April 2026", "activationDate": "24 April 2026",
  "dateFormat": "dd MMMM yyyy", "locale": "en"
}
```

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.

[MXWAR-82]: https://mifosforge.jira.com/browse/MXWAR-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group creation and editing now include extra metadata: staff assignment, external identifiers, submission and activation dates.
  * Activation date is submitted only for active groups when provided; date values are normalized and requests now include consistent date format and locale settings for reliable handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->