### PR TITLE
fix: add missing isSelfServiceUser to users API schema

### DIFF
--- a/fineract.yaml
+++ b/fineract.yaml
@@ -44636,6 +44636,8 @@ components:
           example: demomfi@mifos.org
         firstname:
           type: string
+        isSelfServiceUser:
+          type: boolean
           example: App
         id:
           type: integer
@@ -44693,6 +44695,8 @@ components:
         firstname:
           type: string
           example: App
+        isSelfServiceUser:
+          type: boolean
         id:
           type: integer
           format: int64


### PR DESCRIPTION
### Description
Added missing `isSelfServiceUser` field to:
- GetUsersResponse
- GetUsersUserIdResponse

### Why
This field exists in Apache Fineract backend response but is missing from the OpenAPI schema, causing inconsistency in generated frontend types.

### Changes
- Updated fineract.yaml schema
- Regenerated SDK using `npm run generate-sdk`

### Verification
- Verified API response using Postman
- Confirmed field exists in frontend types

#{Issue Number}
Fixes WEB-934

## Screenshots, if any
![Users Page](https://github.com/user-attachments/assets/304c71d9-8e95-47b2-8444-9d6bd974d6f1)


Shown only for verification — field is correctly available from API.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [✓ ] If you have multiple commits please combine them into one commit by squashing them.

- [✓ ] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API schema now supports identifying self-service users in user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->