### PR TITLE
MXWAR-85: add single-commit PR check workflow

### DIFF
--- a/.github/workflows/single-commit-check.yml
+++ b/.github/workflows/single-commit-check.yml
@@ -1,0 +1,32 @@
+name: single-commit-check
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-single-commit:
+    name: Enforce single commit per PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Verify PR has exactly one commit
+        env:
+          COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          echo "This PR has $COMMIT_COUNT commit(s)."
+          if [ "$COMMIT_COUNT" -gt 1 ]; then
+            echo "::error::This PR has $COMMIT_COUNT commits. Please squash them into a single commit before merging."
+            exit 1
+          fi
+          echo "PR has a single commit. Check passed."


### PR DESCRIPTION
This PR enforces the existing squash commit policy automatically, so maintainers no longer need to manually request contributors to squash commits during PR reviews.

Contributors will now receive fast and clear feedback if their branch contains multiple commits.

[MXWAR-85](https://mifosforge.jira.com/browse/MXWAR-85)

<img width="1012" height="264" alt="image" src="https://github.com/user-attachments/assets/1927cfa9-f8f7-44f3-940b-23d664adf51d" />


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `CONTRIBUTING.md`.


[MXWAR-85]: https://mifosforge.jira.com/browse/MXWAR-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated enforcement of single-commit pull request policy on development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->