### PR TITLE
MXWAR-101: Fix global theme persistence after login

### DIFF
--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -9,8 +9,17 @@ import MfNavbar from '@/components/custom/navbar/MfNavbar'
 import { AppSidebar } from '@/components/custom/sidebar/AppSidebar'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { Outlet } from 'react-router-dom'
+import { useLayoutEffect } from 'react'
 
 const Layout = () => {
+  useLayoutEffect(() => {
+    const savedTheme = localStorage.getItem('theme')
+    if (savedTheme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }, [])
   return (
     <SidebarProvider>
       <div className="flex min-h-screen w-full">


### PR DESCRIPTION
**Description**

This PR resolves the issue where the user's selected theme (dark/light background) does not persist after transitioning from the Login page to the main dashboard.

The theme synchronization logic has been extracted from being purely localized in Login.tsx and integrated into the global Layout.tsx wrapper. A passive useEffect now reads the theme key from localStorage upon layout mount, ensuring that the appropriate theme classes are applied to the root document element seamlessly across all protected routes.

**Related Jira Ticket**
Ticket ID: MXWAR-101
Link: https://mifosforge.jira.com/browse/MXWAR-101

**Changes Made**
Added a global useEffect synchronization hook in src/layout/Layout.tsx.

Ensured localStorage checks run immediately on layout instantiation to prevent visual style flickering.

Ran local formatting (prettier) and linting (eslint) checks on altered components to maintain codebase style requirements.


**Before:**


https://github.com/user-attachments/assets/cfd6396d-92cc-4f56-94b0-6ab943d828ba




**After:**



https://github.com/user-attachments/assets/ff6e3fd8-747c-4c1c-879a-e33183312dd1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now remembers and restores your dark-mode preference on load.
  * If dark mode was previously enabled, the interface automatically starts in dark mode when you return.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->