### PR TITLE
docs: add beginner-friendly frontend quick start and troubleshooting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Open the URL shown in the terminal (e.g. `http://localhost:5173`).
 
 ## 🔧 Common Issues & Fixes
 
-| Problem | Cause | Fix |
-|---------|-------|-----|
-| Login fails silently after `git pull` | `.env.development.local` is missing (gitignored) | Re-create the file using Step 2 above |
-| Login page shows no server dropdown | `VITE_FINERACT_API_URL` is empty (Docker proxy mode) | Add the env file from Step 2 |
-| `npm run dev` throws errors | Dependencies out of sync after pull | Run `npm install` again |
-| CORS or TLS error in browser console | Browser blocking self-signed cert on localhost | Use `https://demo.mifos.community` as the server |
-| Stuck on login even with correct password | Stale auth token in browser storage | Open DevTools → Application → Local Storage → delete `mifosToken`, `mifosServer`, `mifosTenant` |
+| Problem                                   | Cause                                                | Fix                                                                                             |
+| ----------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Login fails silently after `git pull`     | `.env.development.local` is missing (gitignored)     | Re-create the file using Step 2 above                                                           |
+| Login page shows no server dropdown       | `VITE_FINERACT_API_URL` is empty (Docker proxy mode) | Add the env file from Step 2                                                                    |
+| `npm run dev` throws errors               | Dependencies out of sync after pull                  | Run `npm install` again                                                                         |
+| CORS or TLS error in browser console      | Browser blocking self-signed cert on localhost       | Use `https://demo.mifos.community` as the server                                                |
+| Stuck on login even with correct password | Stale auth token in browser storage                  | Open DevTools → Application → Local Storage → delete `mifosToken`, `mifosServer`, `mifosTenant` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,65 @@ root/
 
 ## ⚙️ Prerequisites
 
-- A working **Apache Fineract backend** running locally
-- Node.js and npm installed
+- Node.js (>= 18) and npm installed
+- Git
+- **No local backend needed** if you use the public demo server (see Quick Start below)
+
+---
+
+## ⚡ Quick Start (Frontend Only — No Backend Required)
+
+> **Best for new contributors!** Use the public demo Fineract server — no Docker or local backend setup needed.
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/openMF/mifos-x-web-app-react.git
+cd mifos-x-web-app-react
+npm install
+```
+
+### 2. Create your local environment file
+
+Create a file named `.env.development.local` in the project root:
+
+```env
+VITE_FINERACT_API_URL=https://demo.mifos.community
+VITE_FINERACT_API_PROVIDER=/fineract-provider
+VITE_FINERACT_API_VERSION=/api
+VITE_FINERACT_PLATFORM_TENANT_IDENTIFIER=default
+```
+
+> ⚠️ **Important:** `.env.development.local` is git-ignored and will NOT be included when you clone or pull. You must create this file manually every time you do a fresh clone.
+
+### 3. Start the dev server
+
+```bash
+npm run dev
+```
+
+Open the URL shown in the terminal (e.g. `http://localhost:5173`).
+
+### 4. Login with demo credentials
+
+| Field    | Value                          |
+| -------- | ------------------------------ |
+| Server   | `https://demo.mifos.community` |
+| Tenant   | `default`                      |
+| Username | `mifos`                        |
+| Password | `password`                     |
+
+---
+
+## 🔧 Common Issues & Fixes
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Login fails silently after `git pull` | `.env.development.local` is missing (gitignored) | Re-create the file using Step 2 above |
+| Login page shows no server dropdown | `VITE_FINERACT_API_URL` is empty (Docker proxy mode) | Add the env file from Step 2 |
+| `npm run dev` throws errors | Dependencies out of sync after pull | Run `npm install` again |
+| CORS or TLS error in browser console | Browser blocking self-signed cert on localhost | Use `https://demo.mifos.community` as the server |
+| Stuck on login even with correct password | Stale auth token in browser storage | Open DevTools → Application → Local Storage → delete `mifosToken`, `mifosServer`, `mifosTenant` |
 
 ---
 


### PR DESCRIPTION
## Summary
New contributors (including myself) faced a silent login failure 
after cloning/pulling the repo because the `.env.development.local` 
file is git-ignored and was not documented clearly.

## Changes
- Updated Prerequisites — removed "local backend required" assumption
- Added - Quick Start (Frontend Only) section with demo server URL and login credentials
- Added - Common Issues & Fixes table for 5 frequent problems

## Related Issue
Fixes MXWAR-64

## Testing
Verified login works at http://localhost:10706 using demo.mifos.community


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites to clarify that a locally running backend is not required when using the public demo server.
  * Added/expanded a “frontend-only” quick-start guide with setup steps, environment variable examples, and demo login details.
  * Enhanced “common issues & fixes” troubleshooting for login failures, missing server selection, dependency issues after pulls, browser CORS/TLS errors, and stale authentication token behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->