### PR TITLE
fix(MXWAR-108): Sidebar navigation item text truncated on desktop view

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Open the URL shown in the terminal (e.g. `http://localhost:5173`).
 
 ## 🔧 Common Issues & Fixes
 
-| Problem | Cause | Fix |
-|---------|-------|-----|
-| Login fails silently after `git pull` | `.env.development.local` is missing (gitignored) | Re-create the file using Step 2 above |
-| Login page shows no server dropdown | `VITE_FINERACT_API_URL` is empty (Docker proxy mode) | Add the env file from Step 2 |
-| `npm run dev` throws errors | Dependencies out of sync after pull | Run `npm install` again |
-| CORS or TLS error in browser console | Browser blocking self-signed cert on localhost | Use `https://demo.mifos.community` as the server |
-| Stuck on login even with correct password | Stale auth token in browser storage | Open DevTools → Application → Local Storage → delete `mifosToken`, `mifosServer`, `mifosTenant` |
+| Problem                                   | Cause                                                | Fix                                                                                             |
+| ----------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Login fails silently after `git pull`     | `.env.development.local` is missing (gitignored)     | Re-create the file using Step 2 above                                                           |
+| Login page shows no server dropdown       | `VITE_FINERACT_API_URL` is empty (Docker proxy mode) | Add the env file from Step 2                                                                    |
+| `npm run dev` throws errors               | Dependencies out of sync after pull                  | Run `npm install` again                                                                         |
+| CORS or TLS error in browser console      | Browser blocking self-signed cert on localhost       | Use `https://demo.mifos.community` as the server                                                |
+| Stuck on login even with correct password | Stale auth token in browser storage                  | Open DevTools → Application → Local Storage → delete `mifosToken`, `mifosServer`, `mifosTenant` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,65 @@ root/
 
 ## ⚙️ Prerequisites
 
-- A working **Apache Fineract backend** running locally
-- Node.js and npm installed
+- Node.js (>= 18) and npm installed
+- Git
+- **No local backend needed** if you use the public demo server (see Quick Start below)
+
+---
+
+## ⚡ Quick Start (Frontend Only — No Backend Required)
+
+> **Best for new contributors!** Use the public demo Fineract server — no Docker or local backend setup needed.
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/openMF/mifos-x-web-app-react.git
+cd mifos-x-web-app-react
+npm install
+```
+
+### 2. Create your local environment file
+
+Create a file named `.env.development.local` in the project root:
+
+```env
+VITE_FINERACT_API_URL=https://demo.mifos.community
+VITE_FINERACT_API_PROVIDER=/fineract-provider
+VITE_FINERACT_API_VERSION=/api
+VITE_FINERACT_PLATFORM_TENANT_IDENTIFIER=default
+```
+
+> ⚠️ **Important:** `.env.development.local` is git-ignored and will NOT be included when you clone or pull. You must create this file manually every time you do a fresh clone.
+
+### 3. Start the dev server
+
+```bash
+npm run dev
+```
+
+Open the URL shown in the terminal (e.g. `http://localhost:5173`).
+
+### 4. Login with demo credentials
+
+| Field    | Value                          |
+| -------- | ------------------------------ |
+| Server   | `https://demo.mifos.community` |
+| Tenant   | `default`                      |
+| Username | `mifos`                        |
+| Password | `password`                     |
+
+---
+
+## 🔧 Common Issues & Fixes
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Login fails silently after `git pull` | `.env.development.local` is missing (gitignored) | Re-create the file using Step 2 above |
+| Login page shows no server dropdown | `VITE_FINERACT_API_URL` is empty (Docker proxy mode) | Add the env file from Step 2 |
+| `npm run dev` throws errors | Dependencies out of sync after pull | Run `npm install` again |
+| CORS or TLS error in browser console | Browser blocking self-signed cert on localhost | Use `https://demo.mifos.community` as the server |
+| Stuck on login even with correct password | Stale auth token in browser storage | Open DevTools → Application → Local Storage → delete `mifosToken`, `mifosServer`, `mifosTenant` |
 
 ---
 

--- a/src/components/custom/sidebar/AppSidebar.tsx
+++ b/src/components/custom/sidebar/AppSidebar.tsx
@@ -158,7 +158,7 @@ export const AppSidebar = () => {
                 <SidebarMenuButton asChild>
                   <Button
                     variant="ghost"
-                    className="w-full justify-start gap-3 text-lg font-medium text-black dark:text-white hover:text-primary cursor-pointer"
+                    className="w-full justify-start gap-3 text-sm font-medium text-black dark:text-white hover:text-primary cursor-pointer"
                     onClick={() => handleClick(route)}
                   >
                     {icon}
@@ -172,7 +172,7 @@ export const AppSidebar = () => {
               <SidebarMenuButton asChild>
                 <Button
                   variant="ghost"
-                  className="w-full justify-start gap-3 text-lg font-medium text-black dark:text-white hover:text-primary cursor-pointer"
+                  className="w-full justify-start gap-3 text-sm font-medium text-black dark:text-white hover:text-primary cursor-pointer"
                 >
                   <Keyboard />
                   <p>{t('nav.keyboardShortcuts')}</p>
@@ -184,7 +184,7 @@ export const AppSidebar = () => {
               <SidebarMenuButton asChild>
                 <Button
                   variant="ghost"
-                  className="w-full justify-start gap-3 text-lg font-medium text-black dark:text-white hover:text-primary cursor-pointer"
+                  className="w-full justify-start gap-3 text-sm font-medium text-black dark:text-white hover:text-primary cursor-pointer"
                 >
                   <CircleHelp />
                   <p>


### PR DESCRIPTION
## Description

Reduced font size of sidebar navigation menu items from `text-lg` 
to `text-sm` to prevent text truncation on desktop view. Items like 
"Checker Inbox and Tasks" and "Individual Collection Sheet" were 
getting cut off due to insufficient sidebar width.

## Related issues and discussion

MXWAR-108

## Screenshots, if any
<img width="827" height="495" alt="image" src="https://github.com/user-attachments/assets/0a7ee372-3934-4a3d-a957-e9a0cd9991f1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions with current prerequisites and a frontend-only quick-start guide.
  * Clarified demo server usage, credentials, environment configuration, and troubleshooting steps.
  * Removed the requirement to run a local backend.

* **Style**
  * Reduced sidebar navigation text size for improved visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->